### PR TITLE
Fix timestamp correction

### DIFF
--- a/FFmpegInterop/Source/MediaSampleProvider.cpp
+++ b/FFmpegInterop/Source/MediaSampleProvider.cpp
@@ -100,12 +100,6 @@ MediaStreamSample^ MediaSampleProvider::GetNextSample()
 		// Write the packet out
 		hr = WriteAVPacketToStream(dataWriter, &avPacket);
 
-		// Use decoding timestamp if presentation timestamp is not valid
-		if (avPacket.pts == AV_NOPTS_VALUE && avPacket.dts != AV_NOPTS_VALUE)
-		{
-			avPacket.pts = avPacket.dts;
-		}
-
 		Windows::Foundation::TimeSpan pts = { LONGLONG(av_q2d(m_pAvFormatCtx->streams[m_streamIndex]->time_base) * 10000000 * avPacket.pts) };
 		Windows::Foundation::TimeSpan dur = { LONGLONG(av_q2d(m_pAvFormatCtx->streams[m_streamIndex]->time_base) * 10000000 * avPacket.duration) };
 

--- a/FFmpegInterop/Source/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedVideoSampleProvider.cpp
@@ -122,14 +122,14 @@ HRESULT UncompressedVideoSampleProvider::DecodeAVPacket(DataWriter^ dataWriter, 
 	int frameComplete = 0;
 	if (avcodec_decode_video2(m_pAvCodecCtx, m_pAvFrame, &frameComplete, avPacket) < 0)
 	{
-		DebugMessage(L"GetNextSample reaching EOF\n");
+		DebugMessage(L"DecodeAVPacket Failed\n");
 		frameComplete = 1;
 	}
 	else
 	{
 		if (frameComplete)
 		{
-			avPacket->pts = m_pAvFrame->pkt_pts;
+			avPacket->pts = av_frame_get_best_effort_timestamp(m_pAvFrame);
 		}
 	}
 


### PR DESCRIPTION
When decoding DivX video (and VC1 etc), m_pAvFrame->pkt_pts contains AV_NOPTS_VALUE right after complete frame decoding. The reason why it still works at the moment is the extra timestamp correction logic in MediaSampleProvider that simply use the dts,

av_frame_get_best_effort_timestamp() seems to correctly return the right pts in my tests. With this correction, I no longer have to correct the pts in MediaSampleProvider as well. Could you please verify with your media files and let us know if you have any issue?

