### PR TITLE
Fixing wrong pcm frame length to match the actual number of samples

### DIFF
--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
@@ -121,7 +121,7 @@ HRESULT UncompressedAudioSampleProvider::DecodeAVPacket(DataWriter^ dataWriter, 
 			uint8_t *resampledData = nullptr;
 			unsigned int aBufferSize = av_samples_alloc(&resampledData, NULL, m_pAvFrame->channels, m_pAvFrame->nb_samples, AV_SAMPLE_FMT_S16, 0);
 			int resampledDataSize = swr_convert(m_pSwrCtx, &resampledData, aBufferSize, (const uint8_t **)m_pAvFrame->extended_data, m_pAvFrame->nb_samples);
-			auto aBuffer = ref new Platform::Array<uint8_t>(resampledData, aBufferSize);
+			auto aBuffer = ref new Platform::Array<uint8_t>(resampledData, resampledDataSize * m_pAvFrame->channels * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16));
 			dataWriter->WriteBytes(aBuffer);
 			av_freep(&resampledData);
 			av_frame_unref(m_pAvFrame);

--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
@@ -121,7 +121,7 @@ HRESULT UncompressedAudioSampleProvider::DecodeAVPacket(DataWriter^ dataWriter, 
 			uint8_t *resampledData = nullptr;
 			unsigned int aBufferSize = av_samples_alloc(&resampledData, NULL, m_pAvFrame->channels, m_pAvFrame->nb_samples, AV_SAMPLE_FMT_S16, 0);
 			int resampledDataSize = swr_convert(m_pSwrCtx, &resampledData, aBufferSize, (const uint8_t **)m_pAvFrame->extended_data, m_pAvFrame->nb_samples);
-			auto aBuffer = ref new Platform::Array<uint8_t>(resampledData, resampledDataSize * m_pAvFrame->channels * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16));
+			auto aBuffer = ref new Platform::Array<uint8_t>(resampledData, min(aBufferSize, (unsigned int)(resampledDataSize * m_pAvFrame->channels * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16))));
 			dataWriter->WriteBytes(aBuffer);
 			av_freep(&resampledData);
 			av_frame_unref(m_pAvFrame);


### PR DESCRIPTION
Hi, 

as I said in this thread https://github.com/Microsoft/FFmpegInterop/issues/24, I encountered an issue while playing dvd_pcm streams. Two of the files I provide in this folder http://1drv.ms/1fmUZxd exhibit this issue on their pcm stream (the default one) : the dts sparks vob and vts_04_04 vob. 

It looks like av_samples_alloc return value can not reliably be used to get the resampled data range. Instead, my change relies on swr_convert return value to get it. 