### PR TITLE
export full current PATH from environment into MSYS2

### DIFF
--- a/BuildFFmpeg.bat
+++ b/BuildFFmpeg.bat
@@ -12,6 +12,9 @@ set BUILD.win10=N
 set BUILD.win8.1=N
 set BUILD.phone8.1=N
 
+:: Export full current PATH from environment into MSYS2
+set MSYS2_PATH_TYPE=inherit
+
 :: Iterate through arguments and set the right configuration
 for %%a in (%*) do (
     if /I "%%a"=="ARM" (


### PR DESCRIPTION
This pull request fixes the cl.exe not found error when building ffmpeg for winrt with newer versions of msys. We need to call set MSYS2_PATH_TYPE=inherit from BuildFFmpeg.bat since the script directly launches bash.exe.

This PR fixes issues:

https://github.com/Microsoft/FFmpegInterop/issues/64
https://github.com/Microsoft/FFmpegInterop/issues/60
https://github.com/Microsoft/FFmpegInterop/issues/40
https://github.com/Microsoft/FFmpegInterop/issues/49
