### PR TITLE
Fixing crashing issue when multiple frames are in one audio packet.

### DIFF
--- a/FFmpegInterop/Source/UncompressedSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedSampleProvider.cpp
@@ -81,8 +81,12 @@ HRESULT UncompressedSampleProvider::DecodeAVPacket(DataWriter^ dataWriter, AVPac
 
 	bool consumed = false;
 	hr = GetFrameFromFFmpegDecoder(avPacket, consumed);
-	framePts = m_pAvFrame->pkt_pts;
-	frameDuration = m_pAvFrame->pkt_duration;
+	// Update the timestamp if the packet has one
+	if (m_pAvFrame->pts != AV_NOPTS_VALUE)
+	{
+		framePts = m_pAvFrame->pts;
+		frameDuration = m_pAvFrame->pkt_duration;
+	}
 
 	// If we didn't consume the packet, put it back in the queue
 	if (!consumed)


### PR DESCRIPTION
When more than a single frame is part of a single compressed audio packet.
We push the packet back onto our queue, but remove the reference to it since
we processed part of it. The next time we try to use the partial packet, it
has been freed. Keep the reference on the packet when pushing it back to the
queue.

Also fix the timestamp for these packets. The frame might not have a pts
value, so keep the one from the packet.

Addresses issues #99 and #103