### PR TITLE
Fix 24-bit decoded audio

### DIFF
--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -455,9 +455,8 @@ HRESULT FFmpegInteropMSS::CreateAudioStreamDescriptor(bool forceAudioDecode)
 	}
 	else
 	{
-		// Set default 16 bits when bits per sample value is unknown (0)
-		unsigned int bitsPerSample = avAudioCodecCtx->bits_per_coded_sample ? avAudioCodecCtx->bits_per_coded_sample : 16;
-		audioStreamDescriptor = ref new AudioStreamDescriptor(AudioEncodingProperties::CreatePcm(avAudioCodecCtx->sample_rate, avAudioCodecCtx->channels, bitsPerSample));
+		// We always convert to 16-bit audio so set the size here
+		audioStreamDescriptor = ref new AudioStreamDescriptor(AudioEncodingProperties::CreatePcm(avAudioCodecCtx->sample_rate, avAudioCodecCtx->channels, 16));
 		audioSampleProvider = ref new UncompressedAudioSampleProvider(m_pReader, avFormatCtx, avAudioCodecCtx);
 	}
 

--- a/FFmpegInterop/Source/MediaSampleProvider.cpp
+++ b/FFmpegInterop/Source/MediaSampleProvider.cpp
@@ -142,17 +142,6 @@ void MediaSampleProvider::QueuePacket(AVPacket packet)
 	m_packetQueue.push_back(packet);
 }
 
-void MediaSampleProvider::HeadQueuePacket(AVPacket packet)
-{
-	DebugMessage(L" - HeadQueuePacket\n");
-
-	// Add a reference to the packet since we're pushing it back into the queue
-	AVPacket temp;
-	av_init_packet(&temp);
-	av_packet_ref(&temp, &packet);
-	m_packetQueue.insert(m_packetQueue.begin(), temp);
-}
-
 AVPacket MediaSampleProvider::PopPacket()
 {
 	DebugMessage(L" - PopPacket\n");

--- a/FFmpegInterop/Source/MediaSampleProvider.h
+++ b/FFmpegInterop/Source/MediaSampleProvider.h
@@ -42,7 +42,6 @@ namespace FFmpegInterop
 
 	internal:
 		void QueuePacket(AVPacket packet);
-		void HeadQueuePacket(AVPacket packet);
 		AVPacket PopPacket();
 
 	private:

--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
@@ -68,15 +68,6 @@ HRESULT UncompressedAudioSampleProvider::AllocateResources()
 		}
 	}
 
-	if (SUCCEEDED(hr))
-	{
-		m_pAvFrame = av_frame_alloc();
-		if (!m_pAvFrame)
-		{
-			hr = E_OUTOFMEMORY;
-		}
-	}
-
 	return hr;
 }
 
@@ -108,6 +99,7 @@ HRESULT UncompressedAudioSampleProvider::ProcessDecodedFrame(DataWriter^ dataWri
 	dataWriter->WriteBytes(aBuffer);
 	av_freep(&resampledData);
 	av_frame_unref(m_pAvFrame);
+	av_freep(m_pAvFrame);
 
 	return S_OK;
 }

--- a/FFmpegInterop/Source/UncompressedSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedSampleProvider.cpp
@@ -33,30 +33,32 @@ HRESULT UncompressedSampleProvider::ProcessDecodedFrame(DataWriter^ dataWriter)
 }
 
 // Return S_FALSE for an incomplete frame
-HRESULT UncompressedSampleProvider::GetFrameFromFFmpegDecoder(AVPacket* avPacket, bool& consumed)
+HRESULT UncompressedSampleProvider::GetFrameFromFFmpegDecoder(AVPacket* avPacket)
 {
 	HRESULT hr = S_OK;
-	consumed = true;
 	int decodeFrame = 0;
 
-	int sendPacketResult = avcodec_send_packet(m_pAvCodecCtx, avPacket);
-	if (sendPacketResult == AVERROR(EAGAIN))
+	if (avPacket != nullptr)
 	{
-		// We couldn't feed the packet to the decoder.
-		// Keep it for next time
-		consumed = false;
+		int sendPacketResult = avcodec_send_packet(m_pAvCodecCtx, avPacket);
+		if (sendPacketResult == AVERROR(EAGAIN))
+		{
+			// The decoder should have been drained and always ready to access input
+			_ASSERT(FALSE);
+			hr = E_UNEXPECTED;
+		}
+		else if (sendPacketResult < 0)
+		{
+			// We failed to send the packet
+			hr = E_FAIL;
+			DebugMessage(L"Decoder failed on the sample\n");
+		}
 	}
-	else if (sendPacketResult < 0)
+	if (SUCCEEDED(hr))
 	{
-		// We failed to send the packet
-		hr = E_FAIL;
-		DebugMessage(L"Decoder failed on the sample\n");
-	}
-
-	if(SUCCEEDED(hr))
-	{
+		AVFrame *pFrame = av_frame_alloc();
 		// Try to get a frame from the decoder.
-		decodeFrame = avcodec_receive_frame(m_pAvCodecCtx, m_pAvFrame);
+		decodeFrame = avcodec_receive_frame(m_pAvCodecCtx, pFrame);
 
 		// The decoder is empty, send a packet to it.
 		if (decodeFrame == AVERROR(EAGAIN))
@@ -64,11 +66,19 @@ HRESULT UncompressedSampleProvider::GetFrameFromFFmpegDecoder(AVPacket* avPacket
 			// The decoder doesn't have enough data to produce a frame,
 			// return S_FALSE to indicate a partial frame
 			hr = S_FALSE;
+			av_frame_unref(pFrame);
+			av_freep(pFrame);
 		}
 		else if (decodeFrame < 0)
 		{
 			hr = E_FAIL;
+			av_frame_unref(pFrame);
+			av_freep(pFrame);
 			DebugMessage(L"Failed to get a frame from the decoder\n");
+		}
+		else
+		{
+			m_pAvFrame = pFrame;
 		}
 	}
 
@@ -78,26 +88,35 @@ HRESULT UncompressedSampleProvider::GetFrameFromFFmpegDecoder(AVPacket* avPacket
 HRESULT UncompressedSampleProvider::DecodeAVPacket(DataWriter^ dataWriter, AVPacket* avPacket, int64_t& framePts, int64_t& frameDuration)
 {
 	HRESULT hr = S_OK;
+	bool fGotFrame  = false;
+	AVPacket *pPacket = avPacket;
 
-	bool consumed = false;
-	hr = GetFrameFromFFmpegDecoder(avPacket, consumed);
-	// Update the timestamp if the packet has one
-	if (m_pAvFrame->pts != AV_NOPTS_VALUE)
+	while (SUCCEEDED(hr))
 	{
-		framePts = m_pAvFrame->pts;
-		frameDuration = m_pAvFrame->pkt_duration;
-	}
+		hr = GetFrameFromFFmpegDecoder(pPacket);
+		pPacket = nullptr;
+		if (SUCCEEDED(hr))
+		{
+			if (hr == S_FALSE)
+			{
+				// If the decoder didn't give an initial frame we still need
+				// to feed it more frames. Keep S_FALSE as the result
+				if (fGotFrame)
+				{
+					hr = S_OK;
+				}
+				break;
+			}
+			// Update the timestamp if the packet has one
+			else if (m_pAvFrame->pts != AV_NOPTS_VALUE)
+			{
+				framePts = m_pAvFrame->pts;
+				frameDuration = m_pAvFrame->pkt_duration;
+			}
+			fGotFrame = true;
 
-	// If we didn't consume the packet, put it back in the queue
-	if (!consumed)
-	{
-		HeadQueuePacket(*avPacket);
-	}
-
-	// If we couldn't get a complete frame (S_FALSE), don't process the frame yet
-	if (SUCCEEDED(hr) && hr != S_FALSE)
-	{
-		hr = ProcessDecodedFrame(dataWriter);
+			hr = ProcessDecodedFrame(dataWriter);
+		}
 	}
 
 	return hr;

--- a/FFmpegInterop/Source/UncompressedSampleProvider.h
+++ b/FFmpegInterop/Source/UncompressedSampleProvider.h
@@ -30,7 +30,7 @@ namespace FFmpegInterop
 	{
 	internal:
 		// Try to get a frame from FFmpeg, otherwise, feed a frame to start decoding
-		virtual HRESULT GetFrameFromFFmpegDecoder(AVPacket* avPacket, bool& consumed);
+		virtual HRESULT GetFrameFromFFmpegDecoder(AVPacket* avPacket);
 		virtual HRESULT DecodeAVPacket(DataWriter^ dataWriter, AVPacket* avPacket, int64_t& framePts, int64_t& frameDuration) override;
 		virtual HRESULT ProcessDecodedFrame(DataWriter^ dataWriter);
 		UncompressedSampleProvider(

--- a/FFmpegInterop/Source/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedVideoSampleProvider.cpp
@@ -127,6 +127,7 @@ HRESULT UncompressedVideoSampleProvider::WriteAVPacketToStream(DataWriter^ dataW
 	dataWriter->WriteBytes(YBuffer);
 	dataWriter->WriteBytes(UVBuffer);
 	av_frame_unref(m_pAvFrame);
+	av_freep(m_pAvFrame);
 
 	return S_OK;
 }


### PR DESCRIPTION
Since we always use an audio converter when having FFmpeg decode audio. The audio stream descriptor should specify the audio sample size as 16 bit since that's the format that we'll feed to the media pipeline.