### PR TITLE
Add releasing of the stream in destructor

### DIFF
--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -30,7 +30,6 @@ extern "C"
 #include <libavutil/imgutils.h>
 }
 
-
 using namespace concurrency;
 using namespace FFmpegInterop;
 using namespace Platform;

--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -83,7 +83,11 @@ FFmpegInteropMSS::~FFmpegInteropMSS()
 	avformat_close_input(&avFormatCtx);
 	av_free(avIOCtx);
 	av_dict_free(&avDict);
-	fileStreamData->Release();
+	
+	if (fileStreamData != nullptr)
+	{
+		fileStreamData->Release();
+	}
 }
 
 FFmpegInteropMSS^ FFmpegInteropMSS::CreateFFmpegInteropMSSFromStream(IRandomAccessStream^ stream, bool forceAudioDecode, bool forceVideoDecode, PropertySet^ ffmpegOptions)

--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -1,4 +1,4 @@
-﻿//*****************************************************************************
+//*****************************************************************************
 //
 //	Copyright 2015 Microsoft Corporation
 //
@@ -29,6 +29,7 @@ extern "C"
 {
 #include <libavutil/imgutils.h>
 }
+
 
 using namespace concurrency;
 using namespace FFmpegInterop;
@@ -83,6 +84,7 @@ FFmpegInteropMSS::~FFmpegInteropMSS()
 	avformat_close_input(&avFormatCtx);
 	av_free(avIOCtx);
 	av_dict_free(&avDict);
+	fileStreamData->Release();
 }
 
 FFmpegInteropMSS^ FFmpegInteropMSS::CreateFFmpegInteropMSSFromStream(IRandomAccessStream^ stream, bool forceAudioDecode, bool forceVideoDecode, PropertySet^ ffmpegOptions)


### PR DESCRIPTION
There seems to be a memory leak once you don't release the stream in destructor. This should fix that.