### PR TITLE
Fix video orientation & thread racing

### DIFF
--- a/FFmpegInterop/Source/FFmpegInteropMSS.h
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.h
@@ -76,7 +76,11 @@ namespace FFmpegInterop
 		VideoStreamDescriptor^ videoStreamDescriptor;
 		int audioStreamIndex;
 		int videoStreamIndex;
-
+		
+		bool rotateVideo;
+		int rotationAngle;
+		std::recursive_mutex mutexGuard;
+		
 		MediaSampleProvider^ audioSampleProvider;
 		MediaSampleProvider^ videoSampleProvider;
 


### PR DESCRIPTION
videos recorded with smartphone camera in portrait mode rotate the output at an angle (usually 90 degrees). FFMPEG interop does not take this into account.

Added bonus: fix for thread race between destructor and sample request.