### PR TITLE
Logging plumbing

### DIFF
--- a/FFmpegInterop/Source/FFmpegInteropLogging.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropLogging.cpp
@@ -1,0 +1,62 @@
+//*****************************************************************************
+//
+//	Copyright 2017 Microsoft Corporation
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	http ://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+//
+//*****************************************************************************
+
+#include "pch.h"
+#include "FFmpegInteropLogging.h"
+
+using namespace FFmpegInterop;
+
+extern "C"
+{
+#include <libavutil/log.h>
+}
+
+ILogProvider^ FFmpegInteropLogging::s_pLogProvider = nullptr;
+
+FFmpegInteropLogging::FFmpegInteropLogging()
+{
+}
+
+void FFmpegInteropLogging::SetLogLevel(LogLevel level)
+{
+	av_log_set_level((int)level);
+}
+
+void FFmpegInteropLogging::SetLogProvider(ILogProvider^ logProvider)
+{
+	s_pLogProvider = logProvider;
+	av_log_set_callback([](void*avcl, int level, const char *fmt, va_list vl)->void
+	{
+		if (s_pLogProvider != nullptr)
+		{
+			char pLine[1000];
+			int printPrefix = 1;
+			av_log_format_line(avcl, level, fmt, vl, pLine, sizeof(pLine), &printPrefix);
+
+			wchar_t wLine[sizeof(pLine)];
+			MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pLine, -1, wLine, sizeof(pLine));
+			s_pLogProvider->Log((LogLevel)level, ref new String(wLine));
+		}
+	});
+}
+
+void FFmpegInteropLogging::SetDefaultLogProvider()
+{
+	av_log_set_callback(av_log_default_callback);
+}
+

--- a/FFmpegInterop/Source/FFmpegInteropLogging.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropLogging.cpp
@@ -1,3 +1,4 @@
+
 //*****************************************************************************
 //
 //	Copyright 2017 Microsoft Corporation
@@ -51,8 +52,10 @@ void FFmpegInteropLogging::SetLogProvider(ILogProvider^ logProvider)
 				av_log_format_line(avcl, level, fmt, vl, pLine, sizeof(pLine), &printPrefix);
 
 				wchar_t wLine[sizeof(pLine)];
-				MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pLine, -1, wLine, sizeof(pLine));
-				s_pLogProvider->Log((LogLevel)level, ref new String(wLine));
+				if (MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pLine, -1, wLine, sizeof(pLine)) != 0)
+				{
+					s_pLogProvider->Log((LogLevel)level, ref new String(wLine));
+				}
 			}
 		}
 	});

--- a/FFmpegInterop/Source/FFmpegInteropLogging.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropLogging.cpp
@@ -42,15 +42,18 @@ void FFmpegInteropLogging::SetLogProvider(ILogProvider^ logProvider)
 	s_pLogProvider = logProvider;
 	av_log_set_callback([](void*avcl, int level, const char *fmt, va_list vl)->void
 	{
-		if (s_pLogProvider != nullptr)
+		if (level <= av_log_get_level())
 		{
-			char pLine[1000];
-			int printPrefix = 1;
-			av_log_format_line(avcl, level, fmt, vl, pLine, sizeof(pLine), &printPrefix);
+			if (s_pLogProvider != nullptr)
+			{
+				char pLine[1000];
+				int printPrefix = 1;
+				av_log_format_line(avcl, level, fmt, vl, pLine, sizeof(pLine), &printPrefix);
 
-			wchar_t wLine[sizeof(pLine)];
-			MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pLine, -1, wLine, sizeof(pLine));
-			s_pLogProvider->Log((LogLevel)level, ref new String(wLine));
+				wchar_t wLine[sizeof(pLine)];
+				MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pLine, -1, wLine, sizeof(pLine));
+				s_pLogProvider->Log((LogLevel)level, ref new String(wLine));
+			}
 		}
 	});
 }

--- a/FFmpegInterop/Source/FFmpegInteropLogging.h
+++ b/FFmpegInterop/Source/FFmpegInteropLogging.h
@@ -1,0 +1,36 @@
+//*****************************************************************************
+//
+//	Copyright 2017 Microsoft Corporation
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	http ://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+//
+//*****************************************************************************
+
+#pragma once
+#include "ILogProvider.h"
+
+namespace FFmpegInterop
+{
+	public ref class FFmpegInteropLogging sealed
+	{
+		static void SetLogLevel(LogLevel level);
+		static void SetLogProvider(ILogProvider^ logProvider);
+		static void SetDefaultLogProvider();
+
+	private:
+		FFmpegInteropLogging();
+
+		static ILogProvider^ s_pLogProvider;
+	};
+}
+

--- a/FFmpegInterop/Source/FFmpegInteropLogging.h
+++ b/FFmpegInterop/Source/FFmpegInteropLogging.h
@@ -23,6 +23,7 @@ namespace FFmpegInterop
 {
 	public ref class FFmpegInteropLogging sealed
 	{
+	public:
 		static void SetLogLevel(LogLevel level);
 		static void SetLogProvider(ILogProvider^ logProvider);
 		static void SetDefaultLogProvider();

--- a/FFmpegInterop/Source/ILogProvider.h
+++ b/FFmpegInterop/Source/ILogProvider.h
@@ -1,0 +1,43 @@
+//*****************************************************************************
+//
+//	Copyright 2017 Microsoft Corporation
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	http ://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+//
+//*****************************************************************************
+
+#pragma once
+
+using namespace Platform;
+
+namespace FFmpegInterop
+{
+	// Level values from ffmpeg: libavutil/log.h
+	public enum class LogLevel
+	{
+		Panic = 0,
+		Fatal = 8,
+		Error = 16,
+		Warning = 24,
+		Info = 32,
+		Verbose = 40,
+		Debug = 48,
+		Trace = 56
+	};
+
+	public interface class ILogProvider
+	{
+		void Log(LogLevel level, String^ message);
+	};
+}
+

--- a/FFmpegInterop/Win10/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/Win10/FFmpegInterop/FFmpegInterop.vcxproj
@@ -225,10 +225,12 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\Source\FFmpegInteropLogging.h" />
     <ClInclude Include="..\..\Source\FFmpegInteropMSS.h" />
     <ClInclude Include="..\..\Source\FFmpegReader.h" />
     <ClInclude Include="..\..\Source\H264AVCSampleProvider.h" />
     <ClInclude Include="..\..\Source\H264SampleProvider.h" />
+    <ClInclude Include="..\..\Source\ILogProvider.h" />
     <ClInclude Include="..\..\Source\MediaSampleProvider.h" />
     <ClInclude Include="..\..\Source\UncompressedAudioSampleProvider.h" />
     <ClInclude Include="..\..\Source\UncompressedSampleProvider.h" />
@@ -236,6 +238,7 @@
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\Source\FFmpegInteropLogging.cpp" />
     <ClCompile Include="..\..\Source\FFmpegInteropMSS.cpp" />
     <ClCompile Include="..\..\Source\FFmpegReader.cpp" />
     <ClCompile Include="..\..\Source\H264AVCSampleProvider.cpp" />

--- a/FFmpegInterop/Win10/FFmpegInterop/FFmpegInterop.vcxproj.filters
+++ b/FFmpegInterop/Win10/FFmpegInterop/FFmpegInterop.vcxproj.filters
@@ -16,6 +16,7 @@
     <ClCompile Include="..\..\Source\UncompressedAudioSampleProvider.cpp" />
     <ClCompile Include="..\..\Source\UncompressedSampleProvider.cpp" />
     <ClCompile Include="..\..\Source\UncompressedVideoSampleProvider.cpp" />
+    <ClCompile Include="..\..\Source\FFmpegInteropLogging.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -27,5 +28,7 @@
     <ClInclude Include="..\..\Source\UncompressedAudioSampleProvider.h" />
     <ClInclude Include="..\..\Source\UncompressedSampleProvider.h" />
     <ClInclude Include="..\..\Source\UncompressedVideoSampleProvider.h" />
+    <ClInclude Include="..\..\Source\ILogProvider.h" />
+    <ClInclude Include="..\..\Source\FFmpegInteropLogging.h" />
   </ItemGroup>
 </Project>

--- a/FFmpegInterop/Win8.1/FFmpegInterop.Shared/FFmpegInterop.Shared.vcxitems
+++ b/FFmpegInterop/Win8.1/FFmpegInterop.Shared/FFmpegInterop.Shared.vcxitems
@@ -14,10 +14,12 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\FFmpegInteropLogging.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\FFmpegInteropMSS.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\FFmpegReader.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\H264AVCSampleProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\H264SampleProvider.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\ILogProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\MediaSampleProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedAudioSampleProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedSampleProvider.h" />
@@ -25,6 +27,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)pch.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\FFmpegInteropLogging.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\FFmpegInteropMSS.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\FFmpegReader.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\H264AVCSampleProvider.cpp" />

--- a/FFmpegInterop/Win8.1/FFmpegInterop.Shared/FFmpegInterop.Shared.vcxitems.filters
+++ b/FFmpegInterop/Win8.1/FFmpegInterop.Shared/FFmpegInterop.Shared.vcxitems.filters
@@ -10,6 +10,8 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedSampleProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedVideoSampleProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\H264AVCSampleProvider.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\FFmpegInteropLogging.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\ILogProvider.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)pch.cpp">
@@ -23,5 +25,6 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedSampleProvider.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedVideoSampleProvider.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\H264AVCSampleProvider.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\FFmpegInteropLogging.cpp" />
   </ItemGroup>
 </Project>

--- a/Samples/SamplesWin10/MediaPlayerCPP/App.xaml.cpp
+++ b/Samples/SamplesWin10/MediaPlayerCPP/App.xaml.cpp
@@ -48,6 +48,14 @@ App::App()
 {
 	InitializeComponent();
 	Suspending += ref new SuspendingEventHandler(this, &App::OnSuspending);
+
+	FFmpegInterop::FFmpegInteropLogging::SetLogLevel(FFmpegInterop::LogLevel::Info);
+	FFmpegInterop::FFmpegInteropLogging::SetLogProvider(this);
+}
+
+void App::Log(FFmpegInterop::LogLevel level, String^ message)
+{
+	OutputDebugString(message->Data());
 }
 
 /// <summary>

--- a/Samples/SamplesWin10/MediaPlayerCPP/App.xaml.h
+++ b/Samples/SamplesWin10/MediaPlayerCPP/App.xaml.h
@@ -30,13 +30,17 @@ namespace MediaPlayerCPP
 	/// <summary>
 	/// Provides application-specific behavior to supplement the default Application class.
 	/// </summary>
-	ref class App sealed
+	ref class App sealed :
+		public FFmpegInterop::ILogProvider
 	{
 	protected:
 		virtual void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ e) override;
 
 	internal:
 		App();
+
+	public:
+		virtual void Log(FFmpegInterop::LogLevel level, Platform::String^ message);
 
 	private:
 		void OnSuspending(Platform::Object^ sender, Windows::ApplicationModel::SuspendingEventArgs^ e);

--- a/Samples/SamplesWin10/MediaPlayerCS/App.xaml.cs
+++ b/Samples/SamplesWin10/MediaPlayerCS/App.xaml.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
+using FFmpegInterop;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
 using Windows.Foundation;
@@ -38,7 +39,7 @@ namespace MediaPlayerCS
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>
-    sealed partial class App : Application
+    sealed partial class App : Application, ILogProvider
     {
         /// <summary>
         /// Initializes the singleton application object.  This is the first line of authored code
@@ -48,6 +49,13 @@ namespace MediaPlayerCS
         {
             this.InitializeComponent();
             this.Suspending += OnSuspending;
+            FFmpegInteropLogging.SetLogLevel(LogLevel.Info);
+            FFmpegInteropLogging.SetLogProvider(this);
+        }
+
+        public void Log(LogLevel level, string message)
+        {
+            System.Diagnostics.Debug.WriteLine("FFmpeg ({0}): {1}", level, message);
         }
 
         /// <summary>

--- a/Samples/SamplesWin8.1/MediaPlayerCPP/MediaPlayerCPP.Shared/App.xaml.cpp
+++ b/Samples/SamplesWin8.1/MediaPlayerCPP/MediaPlayerCPP.Shared/App.xaml.cpp
@@ -51,6 +51,14 @@ App::App()
 {
 	InitializeComponent();
 	Suspending += ref new SuspendingEventHandler(this, &App::OnSuspending);
+
+	FFmpegInterop::FFmpegInteropLogging::SetLogLevel(FFmpegInterop::LogLevel::Info);
+	FFmpegInterop::FFmpegInteropLogging::SetLogProvider(this);
+}
+
+void App::Log(FFmpegInterop::LogLevel level, String^ message)
+{
+	OutputDebugString(message->Data());
 }
 
 /// <summary>

--- a/Samples/SamplesWin8.1/MediaPlayerCPP/MediaPlayerCPP.Shared/App.xaml.h
+++ b/Samples/SamplesWin8.1/MediaPlayerCPP/MediaPlayerCPP.Shared/App.xaml.h
@@ -30,7 +30,8 @@ namespace MediaPlayerCPP
 	/// <summary>
 	/// Provides application-specific behavior to supplement the default Application class.
 	/// </summary>
-	ref class App sealed
+	ref class App sealed :
+		public FFmpegInterop::ILogProvider
 	{
 	public:
 		App();
@@ -39,6 +40,9 @@ namespace MediaPlayerCPP
 #if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP
 		virtual void OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ e) override;
 #endif
+
+	public:
+		virtual void Log(FFmpegInterop::LogLevel level, Platform::String^ message);
 
 	private:
 #if WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP

--- a/Samples/SamplesWin8.1/MediaPlayerCS/MediaPlayerCS.Shared/App.xaml.cs
+++ b/Samples/SamplesWin8.1/MediaPlayerCS/MediaPlayerCS.Shared/App.xaml.cs
@@ -16,6 +16,7 @@
 //
 //*****************************************************************************
 
+using FFmpegInterop;
 using System;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
@@ -31,7 +32,7 @@ namespace MediaPlayerCS
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>
-    public sealed partial class App : Application
+    public sealed partial class App : Application, ILogProvider
     {
 #if WINDOWS_PHONE_APP
         private TransitionCollection transitions;
@@ -45,6 +46,13 @@ namespace MediaPlayerCS
         {
             this.InitializeComponent();
             this.Suspending += this.OnSuspending;
+            FFmpegInteropLogging.SetLogLevel(LogLevel.Info);
+            FFmpegInteropLogging.SetLogProvider(this);
+        }
+
+        public void Log(LogLevel level, string message)
+        {
+            System.Diagnostics.Debug.WriteLine("FFmpeg ({0}): {1}", level, message);
         }
 
         /// <summary>


### PR DESCRIPTION
This change adds plumbing on the WinRT side for the logging capabilities inside of FFmpeg.  This was invaluable for me recently while I was diagnosing an implementation I was working on, and it seemed too useful not to share.  It also includes sample implementations for C++ and CS sample projects for both UWP and Windows/WindowsPhone 8.1.