### PR TITLE
Fixing memory leak in uncompressed audio and video processing.

### DIFF
--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
@@ -75,7 +75,7 @@ UncompressedAudioSampleProvider::~UncompressedAudioSampleProvider()
 {
 	if (m_pAvFrame)
 	{
-		av_freep(m_pAvFrame);
+		av_frame_free(&m_pAvFrame);
 	}
 
 	// Free 
@@ -99,7 +99,7 @@ HRESULT UncompressedAudioSampleProvider::ProcessDecodedFrame(DataWriter^ dataWri
 	dataWriter->WriteBytes(aBuffer);
 	av_freep(&resampledData);
 	av_frame_unref(m_pAvFrame);
-	av_freep(m_pAvFrame);
+	av_frame_free(&m_pAvFrame);
 
 	return S_OK;
 }

--- a/FFmpegInterop/Source/UncompressedSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedSampleProvider.cpp
@@ -67,13 +67,13 @@ HRESULT UncompressedSampleProvider::GetFrameFromFFmpegDecoder(AVPacket* avPacket
 			// return S_FALSE to indicate a partial frame
 			hr = S_FALSE;
 			av_frame_unref(pFrame);
-			av_freep(pFrame);
+			av_frame_free(&pFrame);
 		}
 		else if (decodeFrame < 0)
 		{
 			hr = E_FAIL;
 			av_frame_unref(pFrame);
-			av_freep(pFrame);
+			av_frame_free(&pFrame);
 			DebugMessage(L"Failed to get a frame from the decoder\n");
 		}
 		else

--- a/FFmpegInterop/Source/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedVideoSampleProvider.cpp
@@ -90,7 +90,7 @@ UncompressedVideoSampleProvider::~UncompressedVideoSampleProvider()
 {
 	if (m_pAvFrame)
 	{
-		av_freep(m_pAvFrame);
+		av_frame_free(&m_pAvFrame);
 	}
 
 	if (m_rgVideoBufferData)
@@ -127,7 +127,7 @@ HRESULT UncompressedVideoSampleProvider::WriteAVPacketToStream(DataWriter^ dataW
 	dataWriter->WriteBytes(YBuffer);
 	dataWriter->WriteBytes(UVBuffer);
 	av_frame_unref(m_pAvFrame);
-	av_freep(m_pAvFrame);
+	av_frame_free(&m_pAvFrame);
 
 	return S_OK;
 }


### PR DESCRIPTION
Frames allocated with av_frame_alloc need to be freed with av_frame_free

Thanks to @mcosmin222 for finding the issue. Issue #142 