### PR TITLE
Dcarpente/small samples fix

### DIFF
--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -40,6 +40,9 @@ using namespace Windows::Media::MediaProperties;
 // Size of the buffer when reading a stream
 const int FILESTREAMBUFFERSZ = 16384;
 
+// Minimum duration for audio samples (50 ms)
+const TimeSpan MINAUDIOSAMPLEDURATION = { 500000 };
+
 // Static functions passed to FFmpeg for stream interop
 static int FileStreamRead(void* ptr, uint8_t* buf, int bufSize);
 static int64_t FileStreamSeek(void* ptr, int64_t pos, int whence);
@@ -693,7 +696,8 @@ void FFmpegInteropMSS::OnSampleRequested(Windows::Media::Core::MediaStreamSource
 	{
 		if (args->Request->StreamDescriptor == audioStreamDescriptor && audioSampleProvider != nullptr)
 		{
-			args->Request->Sample = audioSampleProvider->GetNextSample();
+			// We will force audio samples to be at least 50 ms long
+			args->Request->Sample = audioSampleProvider->GetNextSample(MINAUDIOSAMPLEDURATION);
 		}
 		else if (args->Request->StreamDescriptor == videoStreamDescriptor && videoSampleProvider != nullptr)
 		{

--- a/FFmpegInterop/Source/MediaSampleProvider.cpp
+++ b/FFmpegInterop/Source/MediaSampleProvider.cpp
@@ -57,7 +57,7 @@ void MediaSampleProvider::SetCurrentStreamIndex(int streamIndex)
 
 MediaStreamSample^ MediaSampleProvider::GetNextSample()
 {
-	return this->GetNextSample(Windows::Foundation::TimeSpan({ 50000 }));
+	return this->GetNextSample(Windows::Foundation::TimeSpan({ 0 }));
 }
 
 MediaStreamSample^ MediaSampleProvider::GetNextSample(Windows::Foundation::TimeSpan minDuration)

--- a/FFmpegInterop/Source/MediaSampleProvider.cpp
+++ b/FFmpegInterop/Source/MediaSampleProvider.cpp
@@ -120,15 +120,15 @@ MediaStreamSample^ MediaSampleProvider::GetNextSample(Windows::Foundation::TimeS
 		{
 			// Write the packet out
 			hr = WriteAVPacketToStream(dataWriter, &avPacket);
-      
-      if (m_startOffset == -1)
-		  {
-			  //if we havent set m_startOffset already
-			  DebugMessage(L"Saving m_startOffset\n");
 
-			  //in some real-time streams framePts is less than 0 so we need to make sure m_startOffset is never negative
-			  m_startOffset = framePts < 0 ? 0 : framePts;
-		  }
+			if (m_startOffset == -1)
+			{
+				//if we havent set m_startOffset already
+				DebugMessage(L"Saving m_startOffset\n");
+
+				//in some real-time streams framePts is less than 0 so we need to make sure m_startOffset is never negative
+				m_startOffset = framePts < 0 ? 0 : framePts;
+			}
 
 			if (pts.Duration == 0)
 			{

--- a/FFmpegInterop/Source/MediaSampleProvider.cpp
+++ b/FFmpegInterop/Source/MediaSampleProvider.cpp
@@ -124,10 +124,13 @@ MediaStreamSample^ MediaSampleProvider::GetNextSample(Windows::Foundation::TimeS
 
 		av_packet_unref(&avPacket);
 
-	} while (dur.Duration < minDuration.Duration);
+	} while (SUCCEEDED(hr) && dur.Duration < minDuration.Duration);
 
-	sample = MediaStreamSample::CreateFromBuffer(dataWriter->DetachBuffer(), pts);
-	sample->Duration = dur;
+	if (dur.Duration > 0)
+	{
+		sample = MediaStreamSample::CreateFromBuffer(dataWriter->DetachBuffer(), pts);
+		sample->Duration = dur;
+	}
 
 	return sample;
 }

--- a/FFmpegInterop/Source/MediaSampleProvider.cpp
+++ b/FFmpegInterop/Source/MediaSampleProvider.cpp
@@ -132,7 +132,7 @@ MediaStreamSample^ MediaSampleProvider::GetNextSample(Windows::Foundation::TimeS
 
 			if (pts.Duration == 0)
 			{
-				pts = { LONGLONG(av_q2d(m_pAvFormatCtx->streams[m_streamIndex]->time_base) * 10000000 * framePts) };
+				pts = { LONGLONG(av_q2d(m_pAvFormatCtx->streams[m_streamIndex]->time_base) * 10000000 * (framePts - m_startOffset)) };
 			}
 
 			dur = { dur.Duration + LONGLONG(av_q2d(m_pAvFormatCtx->streams[m_streamIndex]->time_base) * 10000000 * frameDuration) };

--- a/FFmpegInterop/Source/MediaSampleProvider.h
+++ b/FFmpegInterop/Source/MediaSampleProvider.h
@@ -37,6 +37,7 @@ namespace FFmpegInterop
 	public:
 		virtual ~MediaSampleProvider();
 		virtual MediaStreamSample^ GetNextSample();
+		virtual MediaStreamSample^ GetNextSample(Windows::Foundation::TimeSpan minDuration);
 		virtual void Flush();
 		virtual void SetCurrentStreamIndex(int streamIndex);
 


### PR DESCRIPTION
For some files, FFMPEG outputs audio samples that are as short as 2 or 3 ms, which was causing performance issues in our scenarios. This pull request changes MediaSampleProvider::GetNextSample to take in a minSampleDuration argument, and changes FFmpegInteropMSS to request audio samples to have duration >= 50 ms.