### PR TITLE
dcarpente/stream_read_buffer_fix

### DIFF
--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -499,15 +499,10 @@ HRESULT FFmpegInteropMSS::ConvertCodecName(const char* codecName, String^ *outpu
 	// Convert codec name from const char* to Platform::String
 	auto codecNameChars = codecName;
 	size_t newsize = strlen(codecNameChars) + 1;
-	wchar_t * wcstring = nullptr;
-
-	try
+	wchar_t * wcstring = new(std::nothrow) wchar_t[newsize];
+	if (wcstring == nullptr)
 	{
-		wcstring = new wchar_t[newsize];
-	}
-	catch (std::bad_alloc&)
-	{
-		hr = E_FAIL; // couldn't allocate memory for codec name
+		hr = E_OUTOFMEMORY;
 	}
 
 	if (SUCCEEDED(hr))
@@ -715,7 +710,7 @@ static int FileStreamRead(void* ptr, uint8_t* buf, int bufSize)
 
 	// Here we make a temporary copy array, FFMPEG expects buf to remain unmodified on 0 bytesRead 
 	// We can't always guarantee this based on the implementation of IStream::Read 
-	uint8_t* temp = new uint8_t[bufSize];
+	uint8_t* temp = new(std::nothrow) uint8_t[bufSize];
 	if (temp == nullptr)
 	{
 		return -1;


### PR DESCRIPTION
Our usage case uses an IStream implementation that is marshalled across apartments. Because of the way buffers are copied, IStream::Read rewrites the input buffer with null characters even if no bytes are read.

FFMPEG (or at least the OGG container parser) expects FileStreamRead to leave the input ptr unmodified when bytesRead == 0. Since behavior on the buffer for IStream::Read is not defined when bytesRead == 0, we do an additional copy in a temporary buffer to guarantee the behavior FFMPEG expects.