### PR TITLE
added AVSEEK_FLAG_BACKWARD flag to av_seek_frame, also see issue #151

### DIFF
--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -656,7 +656,7 @@ void FFmpegInteropMSS::OnStarting(MediaStreamSource ^sender, MediaStreamSourceSt
 			// Convert TimeSpan unit to AV_TIME_BASE
 			int64_t seekTarget = static_cast<int64_t>(request->StartPosition->Value.Duration / (av_q2d(avFormatCtx->streams[streamIndex]->time_base) * 10000000));
 
-			if (av_seek_frame(avFormatCtx, streamIndex, seekTarget, 0) < 0)
+			if (av_seek_frame(avFormatCtx, streamIndex, seekTarget, AVSEEK_FLAG_BACKWARD) < 0)
 			{
 				DebugMessage(L" - ### Error while seeking\n");
 			}


### PR DESCRIPTION
Some files have an initial timestamp of 0 or -1, which means av_seek_frame will seek to the second timestamp instead of the first when just starting a file. This is especially noticeable for a file like http://xahlee.info/js/i/s/test.oga.

Adding the AVSEEK_FLAG_BACKWARD flag to av_seek_frame results in better behavior for this case.