### PR TITLE
Dcarpente/output compressed web

### DIFF
--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -607,7 +607,7 @@ HRESULT FFmpegInteropMSS::ConvertCodecName(const char* codecName, String^ *outpu
 }
 
 HRESULT FFmpegInteropMSS::CreateAudioStreamDescriptor(bool forceAudioDecode)
-{	
+{
 	if (avAudioCodecCtx->codec_id == AV_CODEC_ID_AAC && !forceAudioDecode)
 	{
 		if (avAudioCodecCtx->extradata_size == 0)

--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -480,42 +480,6 @@ HRESULT FFmpegInteropMSS::InitFFmpegContext(bool forceAudioDecode, bool forceVid
 				}
 			}
 		}
-		else if (!forceVideoDecode)
-		{
-			// FFMPEG doesn't have the codec but we can try to output the encoded type
-			videoStreamIndex = av_find_best_stream(avFormatCtx, AVMEDIA_TYPE_VIDEO, -1, -1, nullptr, 0);
-
-			if (videoStreamIndex != AVERROR_STREAM_NOT_FOUND)
-			{
-				// allocate decoding parameters
-				AVCodecParameters* avVideoCodecParams = avcodec_parameters_alloc();
-				if (!avVideoCodecParams)
-				{
-					hr = E_OUTOFMEMORY;
-					DebugMessage(L"Could not allocate decoding parameters\n");
-					avformat_close_input(&avFormatCtx);
-				}
-
-				if (avcodec_parameters_copy(avVideoCodecParams, avFormatCtx->streams[videoStreamIndex]->codecpar) < 0)
-				{
-					hr = E_FAIL;
-					avformat_close_input(&avFormatCtx);
-				}
-
-				// Create video stream descriptor from parameters
-				hr = CreateVideoStreamDescriptorFromParameters(avVideoCodecParams);
-				if (SUCCEEDED(hr))
-				{
-					hr = videoSampleProvider->AllocateResources();
-					if (SUCCEEDED(hr))
-					{
-						m_pReader->SetVideoStream(videoStreamIndex, videoSampleProvider);
-					}
-				}
-
-				avcodec_parameters_free(&avVideoCodecParams);
-			}
-		}
 	}
 
 	if (SUCCEEDED(hr))
@@ -745,11 +709,6 @@ HRESULT FFmpegInteropMSS::CreateVideoStreamDescriptor(bool forceVideoDecode)
 	videoStreamDescriptor = ref new VideoStreamDescriptor(videoProperties);
 
 	return (videoStreamDescriptor != nullptr && videoSampleProvider != nullptr) ? S_OK : E_OUTOFMEMORY;
-}
-
-HRESULT FFmpegInteropMSS::CreateVideoStreamDescriptorFromParameters(AVCodecParameters* avCodecParams)
-{
-	return E_NOTIMPL;
 }
 
 HRESULT FFmpegInteropMSS::ParseOptions(PropertySet^ ffmpegOptions)

--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -602,7 +602,7 @@ HRESULT FFmpegInteropMSS::ConvertCodecName(const char* codecName, String^ *outpu
 }
 
 HRESULT FFmpegInteropMSS::CreateAudioStreamDescriptor(bool forceAudioDecode)
-{	
+{
 	if (avAudioCodecCtx->codec_id == AV_CODEC_ID_AAC && !forceAudioDecode)
 	{
 		if (avAudioCodecCtx->extradata_size == 0)

--- a/FFmpegInterop/Source/FFmpegInteropMSS.h
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.h
@@ -98,7 +98,6 @@ namespace FFmpegInterop
 		HRESULT CreateAudioStreamDescriptor(bool forceAudioDecode);
 		HRESULT CreateAudioStreamDescriptorFromParameters(AVCodecParameters* avCodecParams);
 		HRESULT CreateVideoStreamDescriptor(bool forceVideoDecode);
-		HRESULT CreateVideoStreamDescriptorFromParameters(AVCodecParameters* avCodecParams);
 		HRESULT ConvertCodecName(const char* codecName, String^ *outputCodecName);
 		HRESULT ParseOptions(PropertySet^ ffmpegOptions);
 		void OnStarting(MediaStreamSource ^sender, MediaStreamSourceStartingEventArgs ^args);

--- a/FFmpegInterop/Source/FFmpegInteropMSS.h
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.h
@@ -96,7 +96,9 @@ namespace FFmpegInterop
 		HRESULT CreateMediaStreamSource(String^ uri, bool forceAudioDecode, bool forceVideoDecode, PropertySet^ ffmpegOptions);
 		HRESULT InitFFmpegContext(bool forceAudioDecode, bool forceVideoDecode);
 		HRESULT CreateAudioStreamDescriptor(bool forceAudioDecode);
+		HRESULT CreateAudioStreamDescriptorFromParameters(AVCodecParameters* avCodecParams);
 		HRESULT CreateVideoStreamDescriptor(bool forceVideoDecode);
+		HRESULT CreateVideoStreamDescriptorFromParameters(AVCodecParameters* avCodecParams);
 		HRESULT ConvertCodecName(const char* codecName, String^ *outputCodecName);
 		HRESULT ParseOptions(PropertySet^ ffmpegOptions);
 		void OnStarting(MediaStreamSource ^sender, MediaStreamSourceStartingEventArgs ^args);
@@ -106,14 +108,14 @@ namespace FFmpegInterop
 		EventRegistrationToken startingRequestedToken;
 		EventRegistrationToken sampleRequestedToken;
 
-		internal:
+	internal:
 		AVDictionary* avDict;
 		AVIOContext* avIOCtx;
 		AVFormatContext* avFormatCtx;
 		AVCodecContext* avAudioCodecCtx;
 		AVCodecContext* avVideoCodecCtx;
 
-		private:
+	private:
 		AudioStreamDescriptor^ audioStreamDescriptor;
 		VideoStreamDescriptor^ videoStreamDescriptor;
 		int audioStreamIndex;

--- a/FFmpegInterop/Source/H264AVCSampleProvider.cpp
+++ b/FFmpegInterop/Source/H264AVCSampleProvider.cpp
@@ -58,6 +58,11 @@ HRESULT H264AVCSampleProvider::GetSPSAndPPSBuffer(DataWriter^ dataWriter)
 	int spsLength = 0;
 	int ppsLength = 0;
 
+	if (!m_pAvCodecCtx)
+	{
+		return E_FAIL;
+	}
+
 	// Get the position of the SPS
 	if (m_pAvCodecCtx->extradata == nullptr && m_pAvCodecCtx->extradata_size < 8)
 	{

--- a/FFmpegInterop/Source/H264SampleProvider.cpp
+++ b/FFmpegInterop/Source/H264SampleProvider.cpp
@@ -56,7 +56,7 @@ HRESULT H264SampleProvider::GetSPSAndPPSBuffer(DataWriter^ dataWriter)
 {
 	HRESULT hr = S_OK;
 
-	if (m_pAvCodecCtx->extradata == nullptr && m_pAvCodecCtx->extradata_size < 8)
+	if (!m_pAvCodecCtx || (m_pAvCodecCtx->extradata == nullptr && m_pAvCodecCtx->extradata_size < 8))
 	{
 		// The data isn't present
 		hr = E_FAIL;

--- a/FFmpegInterop/Source/MediaSampleProvider.cpp
+++ b/FFmpegInterop/Source/MediaSampleProvider.cpp
@@ -51,7 +51,7 @@ MediaSampleProvider::~MediaSampleProvider()
 void MediaSampleProvider::SetCurrentStreamIndex(int streamIndex)
 {
 	DebugMessage(L"SetCurrentStreamIndex\n");
-	if (m_pAvCodecCtx != nullptr && m_pAvFormatCtx->nb_streams > (unsigned int)streamIndex)
+	if (m_pAvFormatCtx->nb_streams > (unsigned int)streamIndex)
 	{
 		m_streamIndex = streamIndex;
 	}


### PR DESCRIPTION
It's possible to build FFMPEG without some codecs, but that makes it impossible for FFmpegInterop to work with sources that use those codecs. This change allows FFmpegInterop to output compressed samples from containers that use Opus codec (like Ogg) while using FFMPEG binaries that were built without the Opus codec. This change should make it easier to add this same functionality for additional audio codecs.

This can be tested by building FFMPEG with --enable-demuxer=ogg flag but without --enable-decoder=opus flag. Example Opus file: http://hpr.dogphilosophy.net/test/opus.opus