### PR TITLE
Fixing playback of raw streams.

### DIFF
--- a/FFmpegInterop/Source/MediaSampleProvider.cpp
+++ b/FFmpegInterop/Source/MediaSampleProvider.cpp
@@ -32,7 +32,7 @@ MediaSampleProvider::MediaSampleProvider(
 	, m_pAvCodecCtx(avCodecCtx)
 	, m_streamIndex(AVERROR_STREAM_NOT_FOUND)
 	, m_startOffset(AV_NOPTS_VALUE)
-	, m_currentPts(0)
+	, m_nextFramePts(0)
 {
 	DebugMessage(L"MediaSampleProvider\n");
 }
@@ -41,7 +41,7 @@ HRESULT MediaSampleProvider::AllocateResources()
 {
 	DebugMessage(L"AllocateResources\n");
 	m_startOffset = AV_NOPTS_VALUE;
-	m_currentPts = 0;
+	m_nextFramePts = 0;
 	return S_OK;
 }
 
@@ -104,12 +104,14 @@ HRESULT MediaSampleProvider::DecodeAVPacket(DataWriter^ dataWriter, AVPacket *av
 		if (avPacket->pts != AV_NOPTS_VALUE)
 		{
 			framePts = avPacket->pts;
-			m_currentPts = framePts;
+			// Set the PTS for the next sample if it doesn't one.
+			m_nextFramePts = framePts + frameDuration;
 		}
 		else
 		{
-			framePts = m_currentPts;
-			m_currentPts += frameDuration;
+			framePts = m_nextFramePts;
+			// Set the PTS for the next sample if it doesn't one.
+			m_nextFramePts += frameDuration;
 		}
 	}
 	return S_OK;

--- a/FFmpegInterop/Source/MediaSampleProvider.h
+++ b/FFmpegInterop/Source/MediaSampleProvider.h
@@ -47,7 +47,8 @@ namespace FFmpegInterop
 	private:
 		std::vector<AVPacket> m_packetQueue;
 		int m_streamIndex;
-		int64 m_startOffset = 0;
+		int64 m_startOffset;
+		int64 m_currentPts;
 
 	internal:
 		// The FFmpeg context. Because they are complex types

--- a/FFmpegInterop/Source/MediaSampleProvider.h
+++ b/FFmpegInterop/Source/MediaSampleProvider.h
@@ -48,7 +48,7 @@ namespace FFmpegInterop
 		std::vector<AVPacket> m_packetQueue;
 		int m_streamIndex;
 		int64 m_startOffset;
-		int64 m_currentPts;
+		int64 m_nextFramePts;
 
 	internal:
 		// The FFmpeg context. Because they are complex types


### PR DESCRIPTION
A rawstream will not have timestamps in samples, so keep a running value based on the duration of samples.