### PR TITLE
Skip corrupted packages

### DIFF
--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
@@ -45,8 +45,8 @@ HRESULT UncompressedAudioSampleProvider::AllocateResources()
 		int64 outChannelLayout = av_get_default_channel_layout(m_pAvCodecCtx->channels);
 
 		// some files report sample duration 0. They also happen to have the m_pAvCodecCtx block_align 0
-		blockAlign = m_pAvCodecCtx->channels * (16 / 8);
-		avgBytesPerSec = m_pAvCodecCtx->sample_rate * blockAlign;
+		m_blockAlign = m_pAvCodecCtx->channels * (16 / 8);
+		m_avgBytesPerSec = m_pAvCodecCtx->sample_rate * blockAlign;
 		
 		// Set up resampler to convert any PCM format (e.g. AV_SAMPLE_FMT_FLTP) to AV_SAMPLE_FMT_S16 PCM format that is expected by Media Element.
 		// Additional logic can be added to avoid resampling PCM data that is already in AV_SAMPLE_FMT_S16_PCM.

--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
@@ -46,7 +46,7 @@ HRESULT UncompressedAudioSampleProvider::AllocateResources()
 
 		// some files report sample duration 0. They also happen to have the m_pAvCodecCtx block_align 0
 		m_blockAlign = m_pAvCodecCtx->channels * (16 / 8);
-		m_avgBytesPerSec = m_pAvCodecCtx->sample_rate * blockAlign;
+		m_avgBytesPerSec = m_pAvCodecCtx->sample_rate * m_blockAlign;
 		
 		// Set up resampler to convert any PCM format (e.g. AV_SAMPLE_FMT_FLTP) to AV_SAMPLE_FMT_S16 PCM format that is expected by Media Element.
 		// Additional logic can be added to avoid resampling PCM data that is already in AV_SAMPLE_FMT_S16_PCM.
@@ -140,7 +140,7 @@ MediaStreamSample^ UncompressedAudioSampleProvider::GetNextSample()
 			}
 			if (dur == 0 && dataWriter->UnstoredBufferLength != 0)
 			{
-				finalDur = (dataWriter->UnstoredBufferLength / avgBytesPerSec) * 10000000;
+				finalDur = (dataWriter->UnstoredBufferLength / m_avgBytesPerSec) * 10000000;
 			}
 			else
 			{

--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
@@ -44,6 +44,10 @@ HRESULT UncompressedAudioSampleProvider::AllocateResources()
 		int64 inChannelLayout = m_pAvCodecCtx->channel_layout ? m_pAvCodecCtx->channel_layout : av_get_default_channel_layout(m_pAvCodecCtx->channels);
 		int64 outChannelLayout = av_get_default_channel_layout(m_pAvCodecCtx->channels);
 
+		// some files report sample duration 0. They also happen to have the m_pAvCodecCtx block_align 0
+		blockAlign = m_pAvCodecCtx->channels * (16 / 8);
+		avgBytesPerSec = m_pAvCodecCtx->sample_rate * blockAlign;
+		
 		// Set up resampler to convert any PCM format (e.g. AV_SAMPLE_FMT_FLTP) to AV_SAMPLE_FMT_S16 PCM format that is expected by Media Element.
 		// Additional logic can be added to avoid resampling PCM data that is already in AV_SAMPLE_FMT_S16_PCM.
 		m_pSwrCtx = swr_alloc_set_opts(
@@ -134,7 +138,14 @@ MediaStreamSample^ UncompressedAudioSampleProvider::GetNextSample()
 			{
 				finalPts = pts;
 			}
-			finalDur += dur;
+			if (dur == 0 && dataWriter->UnstoredBufferLength != 0)
+			{
+				finalDur = (dataWriter->UnstoredBufferLength / avgBytesPerSec) * 10000000;
+			}
+			else
+			{
+				finalDur += dur;
+			}
 		}
 
 	} while (SUCCEEDED(hr) && finalDur < MINAUDIOSAMPLEDURATION);

--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.h
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.h
@@ -31,7 +31,8 @@ namespace FFmpegInterop
 	public:
 		virtual ~UncompressedAudioSampleProvider();
 		virtual MediaStreamSample^ GetNextSample() override;
-
+		long long  blockAlign;
+		long long avgBytesPerSec;
 	internal:
 		UncompressedAudioSampleProvider(
 			FFmpegReader^ reader,

--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.h
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.h
@@ -31,8 +31,8 @@ namespace FFmpegInterop
 	public:
 		virtual ~UncompressedAudioSampleProvider();
 		virtual MediaStreamSample^ GetNextSample() override;
-		long long  blockAlign;
-		long long avgBytesPerSec;
+		int64 blockAlign;
+		int64 avgBytesPerSec;
 	internal:
 		UncompressedAudioSampleProvider(
 			FFmpegReader^ reader,

--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.h
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.h
@@ -31,8 +31,6 @@ namespace FFmpegInterop
 	public:
 		virtual ~UncompressedAudioSampleProvider();
 		virtual MediaStreamSample^ GetNextSample() override;
-		int64 blockAlign;
-		int64 avgBytesPerSec;
 	internal:
 		UncompressedAudioSampleProvider(
 			FFmpegReader^ reader,
@@ -43,6 +41,8 @@ namespace FFmpegInterop
 		virtual HRESULT AllocateResources() override;
 
 	private:
+		int64 m_blockAlign;
+		int64 m_avgBytesPerSec;
 		SwrContext* m_pSwrCtx;
 	};
 }

--- a/FFmpegInterop/Source/UncompressedSampleProvider.h
+++ b/FFmpegInterop/Source/UncompressedSampleProvider.h
@@ -37,7 +37,7 @@ namespace FFmpegInterop
 			FFmpegReader^ reader,
 			AVFormatContext* avFormatCtx,
 			AVCodecContext* avCodecCtx);
-
+		int m_maxCorruptedPackageThreshold;
 	internal:
 		AVFrame* m_pAvFrame;
 	};


### PR DESCRIPTION
Code to skip up to 10 corrupted packages in a row.  Fix for #175 
This can be extended to have a public setter property on the ffmpeg interop MSS if we decide to do so, see #174 

This has been in production for my app for almost 3 weeks with no known side effects. 
Also helps with files with corrupted headers resulting into 0 block aligns.