### PR TITLE
Skip broken packages - different approach

### DIFF
--- a/FFmpegInterop/Source/MediaSampleProvider.h
+++ b/FFmpegInterop/Source/MediaSampleProvider.h
@@ -43,7 +43,7 @@ namespace FFmpegInterop
 	internal:
 		void QueuePacket(AVPacket packet);
 		AVPacket PopPacket();
-		HRESULT GetNextPacket(DataWriter^ writer, LONGLONG& pts, LONGLONG& dur);
+		void DisableStream();
 
 	private:
 		std::vector<AVPacket> m_packetQueue;
@@ -59,6 +59,7 @@ namespace FFmpegInterop
 		FFmpegReader^ m_pReader;
 		AVFormatContext* m_pAvFormatCtx;
 		AVCodecContext* m_pAvCodecCtx;
+		bool m_isDiscontinuous;
 
 	internal:
 		MediaSampleProvider(
@@ -68,5 +69,6 @@ namespace FFmpegInterop
 		virtual HRESULT AllocateResources();
 		virtual HRESULT WriteAVPacketToStream(DataWriter^ writer, AVPacket* avPacket);
 		virtual HRESULT DecodeAVPacket(DataWriter^ dataWriter, AVPacket* avPacket, int64_t& framePts, int64_t& frameDuration);
+		virtual HRESULT GetNextPacket(DataWriter^ writer, LONGLONG& pts, LONGLONG& dur, bool allowSkip);
 	};
 }

--- a/FFmpegInterop/Source/MediaSampleProvider.h
+++ b/FFmpegInterop/Source/MediaSampleProvider.h
@@ -43,6 +43,7 @@ namespace FFmpegInterop
 	internal:
 		void QueuePacket(AVPacket packet);
 		AVPacket PopPacket();
+		HRESULT GetNextPacket(DataWriter^ writer, LONGLONG& pts, LONGLONG& dur);
 
 	private:
 		std::vector<AVPacket> m_packetQueue;
@@ -67,6 +68,5 @@ namespace FFmpegInterop
 		virtual HRESULT AllocateResources();
 		virtual HRESULT WriteAVPacketToStream(DataWriter^ writer, AVPacket* avPacket);
 		virtual HRESULT DecodeAVPacket(DataWriter^ dataWriter, AVPacket* avPacket, int64_t& framePts, int64_t& frameDuration);
-		virtual HRESULT GetNextPacket(DataWriter^ writer, LONGLONG& pts, LONGLONG& dur);
 	};
 }

--- a/FFmpegInterop/Source/MediaSampleProvider.h
+++ b/FFmpegInterop/Source/MediaSampleProvider.h
@@ -49,6 +49,7 @@ namespace FFmpegInterop
 		int m_streamIndex;
 		int64 m_startOffset;
 		int64 m_nextFramePts;
+		bool m_isEnabled;
 
 	internal:
 		// The FFmpeg context. Because they are complex types


### PR DESCRIPTION
I do the skipping of broken packets at a higher level in GetNextPacket. This makes it work automatically for all sample providers. So there is no need to implement it explicitly in each provider (which can be easily forgotten when new providers are added).

Second, once the threshold has been reached, the stream will be flushed and stopped (m_isEnabled = false). This prevents FFmpegReader from pushing new packets into the queue.