### PR TITLE
Sample Presentaion Timestamp

### DIFF
--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -687,10 +687,10 @@ void FFmpegInteropMSS::OnStarting(MediaStreamSource ^sender, MediaStreamSourceSt
 		if (streamIndex >= 0)
 		{
 			// Convert TimeSpan unit to AV_TIME_BASE
-			LONGLONG startTime = avFormatCtx->start_time == AV_NOPTS_VALUE ? 0 : LONGLONG(avFormatCtx->start_time * 10000000 / double(AV_TIME_BASE));
-			int64_t seekTarget = static_cast<int64_t>((request->StartPosition->Value.Duration + startTime) / (av_q2d(avFormatCtx->streams[streamIndex]->time_base) * 10000000));
+			int64_t streamStartTime = avFormatCtx->streams[streamIndex]->start_time == AV_NOPTS_VALUE ? (int64_t)0 : avFormatCtx->streams[streamIndex]->start_time;
+			int64_t seekTarget = static_cast<int64_t>(request->StartPosition->Value.Duration / (av_q2d(avFormatCtx->streams[streamIndex]->time_base) * 10000000));
 
-			if (av_seek_frame(avFormatCtx, streamIndex, seekTarget, AVSEEK_FLAG_BACKWARD) < 0)
+			if (av_seek_frame(avFormatCtx, streamIndex, seekTarget + streamStartTime, AVSEEK_FLAG_BACKWARD) < 0)
 			{
 				DebugMessage(L" - ### Error while seeking\n");
 			}

--- a/FFmpegInterop/Source/MediaSampleProvider.cpp
+++ b/FFmpegInterop/Source/MediaSampleProvider.cpp
@@ -42,7 +42,7 @@ MediaSampleProvider::MediaSampleProvider(
 HRESULT MediaSampleProvider::AllocateResources()
 {
 	DebugMessage(L"AllocateResources\n");
-	m_startOffset = avFormatCtx->start_time == AV_NOPTS_VALUE ? 0 : LONGLONG(avFormatCtx->start_time * 10000000 / double(AV_TIME_BASE));
+	m_startOffset = m_pAvFormatCtx->start_time == AV_NOPTS_VALUE ? 0 : LONGLONG(m_pAvFormatCtx->start_time * 10000000 / double(AV_TIME_BASE));
 	m_nextFramePts = 0;
 	return S_OK;
 }
@@ -217,7 +217,7 @@ HRESULT FFmpegInterop::MediaSampleProvider::GetNextPacket(DataWriter ^ writer, L
 		// Write the packet out
 		hr = WriteAVPacketToStream(writer, &avPacket);
 
-		pts = LONGLONG(av_q2d(m_pAvFormatCtx->streams[m_streamIndex]->time_base) * 10000000 * (framePts - m_startOffset));
+		pts = LONGLONG(av_q2d(m_pAvFormatCtx->streams[m_streamIndex]->time_base) * 10000000 * framePts) - m_startOffset;
 
 		dur = LONGLONG(av_q2d(m_pAvFormatCtx->streams[m_streamIndex]->time_base) * 10000000 * frameDuration);
 	}

--- a/FFmpegInterop/Source/MediaSampleProvider.cpp
+++ b/FFmpegInterop/Source/MediaSampleProvider.cpp
@@ -192,7 +192,7 @@ HRESULT FFmpegInterop::MediaSampleProvider::GetNextPacket(DataWriter ^ writer, L
 			DebugMessage(L"Saving m_startOffset\n");
 
 			//in some real-time streams framePts is less than 0 so we need to make sure m_startOffset is never negative
-			m_startOffset = framePts < 0 ? 0 : framePts;
+			m_startOffset = m_pAvFormatCtx->streams[m_streamIndex]->start_time < 0 ? 0 : m_pAvFormatCtx->streams[m_streamIndex]->start_time;
 		}
 
 		pts = LONGLONG(av_q2d(m_pAvFormatCtx->streams[m_streamIndex]->time_base) * 10000000 * (framePts - m_startOffset));


### PR DESCRIPTION
Fix to use the start_time of the stream for the startOffset instead of the first packet timestamp. From issue #172