### PR TITLE
Fix no seek after file end bug

### DIFF
--- a/FFmpegInterop/Source/MediaSampleProvider.cpp
+++ b/FFmpegInterop/Source/MediaSampleProvider.cpp
@@ -244,11 +244,16 @@ void MediaSampleProvider::Flush()
 		av_packet_unref(&PopPacket());
 	}
 	m_isDiscontinuous = true;
+	m_isEnabled = true;
 }
 
 void MediaSampleProvider::DisableStream()
 {
 	DebugMessage(L"DisableStream\n");
-	Flush();
+	while (!m_packetQueue.empty())
+	{
+		av_packet_unref(&PopPacket());
+	}
+	m_isDiscontinuous = true;
 	m_isEnabled = false;
 }


### PR DESCRIPTION
I noticed that you cannot seek anymore once a file has reached the end. Looks like I introduced this with the corrupt packet skipping. Streams would get disabled on end of file, but never enabled again. This PR will reset the "enabled" flag on seek, so all disabled streams will process data again after a seek.