### PR TITLE
Set default buffer time to zero

### DIFF
--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -490,15 +490,10 @@ HRESULT FFmpegInteropMSS::InitFFmpegContext(bool forceAudioDecode, bool forceVid
 		}
 		if (mss)
 		{
+			mss->BufferTime = { 0 };
 			if (mediaDuration.Duration > 0)
 			{
-				mss->Duration = mediaDuration;
 				mss->CanSeek = true;
-			}
-			else
-			{
-				// Set buffer time to 0 for realtime streaming to reduce latency
-				mss->BufferTime = { 0 };
 			}
 
 			startingRequestedToken = mss->Starting += ref new TypedEventHandler<MediaStreamSource ^, MediaStreamSourceStartingEventArgs ^>(this, &FFmpegInteropMSS::OnStarting);

--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -493,7 +493,8 @@ HRESULT FFmpegInteropMSS::InitFFmpegContext(bool forceAudioDecode, bool forceVid
 			mss->BufferTime = { 0 };
 			if (mediaDuration.Duration > 0)
 			{
-				mss->CanSeek = true;
+				mss->Duration = mediaDuration;
+ 				mss->CanSeek = true;
 			}
 
 			startingRequestedToken = mss->Starting += ref new TypedEventHandler<MediaStreamSource ^, MediaStreamSourceStartingEventArgs ^>(this, &FFmpegInteropMSS::OnStarting);


### PR DESCRIPTION
For normal local file playback, a buffer is not needed at all. Having the default buffer of 1 second gives a bad impression on anyone trying the lib. They will think this lib is slow, because opening files and seeking is so slow. They will see very high RAM usage (at least with high res files). Multiple issues have already been opened on these topics. Let's fix this be setting buffer time to zero by default. 

MSS buffer should only be used in very specific scenarios (e.g. streaming). In that case, the dev needs to try and find out if and which buffer size works best for his sceanrio. But most devs just want this for local file playback, and for them, zero buffer is best.