### PR TITLE
Direct buffer video decoding

### DIFF
--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -26,6 +26,7 @@
 #include "CritSec.h"
 #include "shcore.h"
 #include <mfapi.h>
+#include <dshow.h>
 
 extern "C"
 {
@@ -281,6 +282,34 @@ HRESULT FFmpegInteropMSS::CreateMediaStreamSource(IRandomAccessStream^ stream, b
 	return hr;
 }
 
+static int is_hwaccel_pix_fmt(enum AVPixelFormat pix_fmt)
+{
+	const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(pix_fmt);
+	return desc->flags & AV_PIX_FMT_FLAG_HWACCEL;
+}
+
+static AVPixelFormat get_format(struct AVCodecContext *s, const enum AVPixelFormat *fmt)
+{
+	AVPixelFormat result = (AVPixelFormat)-1;
+	AVPixelFormat format;
+	int index = 0;
+	do
+	{
+		format = fmt[index++];
+		if (format != -1 && result == -1 && !is_hwaccel_pix_fmt(format))
+		{
+			// take first non hw accelerated format
+			result = format;
+		}
+		else if (format == AV_PIX_FMT_NV12 && result != AV_PIX_FMT_YUVA420P)
+		{
+			// switch to NV12 if available, unless this is an alpha channel file
+			result = format;
+		}
+	} while (format != -1);
+	return result;
+}
+
 HRESULT FFmpegInteropMSS::InitFFmpegContext(bool forceAudioDecode, bool forceVideoDecode)
 {
 	HRESULT hr = S_OK;
@@ -398,6 +427,8 @@ HRESULT FFmpegInteropMSS::InitFFmpegContext(bool forceAudioDecode, bool forceVid
 
 				if (SUCCEEDED(hr))
 				{
+					avVideoCodecCtx->get_format = &get_format;
+
 					// initialize the stream parameters with demuxer information
 					if (avcodec_parameters_to_context(avVideoCodecCtx, avFormatCtx->streams[videoStreamIndex]->codecpar) < 0)
 					{
@@ -490,15 +521,11 @@ HRESULT FFmpegInteropMSS::InitFFmpegContext(bool forceAudioDecode, bool forceVid
 		}
 		if (mss)
 		{
+			mss->BufferTime = { 0 };
 			if (mediaDuration.Duration > 0)
 			{
 				mss->Duration = mediaDuration;
 				mss->CanSeek = true;
-			}
-			else
-			{
-				// Set buffer time to 0 for realtime streaming to reduce latency
-				mss->BufferTime = { 0 };
 			}
 
 			startingRequestedToken = mss->Starting += ref new TypedEventHandler<MediaStreamSource ^, MediaStreamSourceStartingEventArgs ^>(this, &FFmpegInteropMSS::OnStarting);
@@ -535,7 +562,7 @@ MediaThumbnailData ^ FFmpegInterop::FFmpegInteropMSS::ExtractThumbnail()
 			}
 
 
-			auto vector = ref new Array<uint8_t>(imageStream->attached_pic.data, imageStream->attached_pic.size);
+			auto vector = ArrayReference<uint8_t>(imageStream->attached_pic.data, imageStream->attached_pic.size);
 			DataWriter^ writer = ref new DataWriter();
 			writer->WriteBytes(vector);
 
@@ -622,13 +649,32 @@ HRESULT FFmpegInteropMSS::CreateVideoStreamDescriptor(bool forceVideoDecode)
 	}
 	else
 	{
-		videoProperties = VideoEncodingProperties::CreateUncompressed(MediaEncodingSubtypes::Nv12, avVideoCodecCtx->width, avVideoCodecCtx->height);
-		videoSampleProvider = ref new UncompressedVideoSampleProvider(m_pReader, avFormatCtx, avVideoCodecCtx);
+		auto sampleProvider = ref new UncompressedVideoSampleProvider(m_pReader, avFormatCtx, avVideoCodecCtx);
+		videoProperties = VideoEncodingProperties::CreateUncompressed(sampleProvider->OutputMediaSubtype, sampleProvider->DecoderWidth, sampleProvider->DecoderHeight);
+		videoSampleProvider = sampleProvider;
+
+		if (sampleProvider->DecoderWidth != avVideoCodecCtx->width || sampleProvider->DecoderHeight != avVideoCodecCtx->height)
+		{
+			MFVideoArea area;
+			area.Area.cx = avVideoCodecCtx->width;
+			area.Area.cy = avVideoCodecCtx->height;
+			area.OffsetX.fract = 0;
+			area.OffsetX.value = 0;
+			area.OffsetY.fract = 0;
+			area.OffsetY.value = 0;
+			videoProperties->Properties->Insert(MF_MT_MINIMUM_DISPLAY_APERTURE, ref new Array<uint8_t>((byte*)&area, sizeof(MFVideoArea)));
+		}
 
 		if (avVideoCodecCtx->sample_aspect_ratio.num > 0 && avVideoCodecCtx->sample_aspect_ratio.den != 0)
 		{
 			videoProperties->PixelAspectRatio->Numerator = avVideoCodecCtx->sample_aspect_ratio.num;
 			videoProperties->PixelAspectRatio->Denominator = avVideoCodecCtx->sample_aspect_ratio.den;
+		}
+
+		if (sampleProvider->GetOutputPixelFormat() == AV_PIX_FMT_YUVJ420P)
+		{
+			// YUVJ420P uses full range values
+			videoProperties->Properties->Insert(MF_MT_VIDEO_NOMINAL_RANGE, (uint32)MFNominalRange_0_255);
 		}
 
 		videoProperties->Properties->Insert(MF_MT_INTERLACE_MODE, (uint32)_MFVideoInterlaceMode::MFVideoInterlace_MixedInterlaceOrProgressive);

--- a/FFmpegInterop/Source/H264AVCSampleProvider.cpp
+++ b/FFmpegInterop/Source/H264AVCSampleProvider.cpp
@@ -76,7 +76,7 @@ HRESULT H264AVCSampleProvider::GetSPSAndPPSBuffer(DataWriter^ dataWriter)
 		}
 		else
 		{
-			auto vSPS = ref new Platform::Array<uint8_t>(spsPos, spsLength);
+			auto vSPS = Platform::ArrayReference<uint8_t>(spsPos, spsLength);
 
 			// Write the NAL unit for the SPS
 			dataWriter->WriteByte(0);
@@ -107,7 +107,7 @@ HRESULT H264AVCSampleProvider::GetSPSAndPPSBuffer(DataWriter^ dataWriter)
 			}
 			else
 			{
-				auto vPPS = ref new Platform::Array<uint8_t>(ppsPos, ppsLength);
+				auto vPPS = Platform::ArrayReference<uint8_t>(ppsPos, ppsLength);
 
 				// Write the NAL unit for the PPS
 				dataWriter->WriteByte(0);
@@ -159,7 +159,7 @@ HRESULT H264AVCSampleProvider::WriteNALPacket(DataWriter^ dataWriter, AVPacket* 
 		}
 
 		// Write the rest of the packet to the stream
-		auto vBuffer = ref new Platform::Array<uint8_t>(&(avPacket->data[index]), size);
+		auto vBuffer = Platform::ArrayReference<uint8_t>(&(avPacket->data[index]), size);
 		dataWriter->WriteBytes(vBuffer);
 		index += size;
 	} while (index < packetSize);

--- a/FFmpegInterop/Source/H264SampleProvider.cpp
+++ b/FFmpegInterop/Source/H264SampleProvider.cpp
@@ -64,7 +64,7 @@ HRESULT H264SampleProvider::GetSPSAndPPSBuffer(DataWriter^ dataWriter)
 	else
 	{
 		// Write both SPS and PPS sequence as is from extradata
-		auto vSPSPPS = ref new Platform::Array<uint8_t>(m_pAvCodecCtx->extradata, m_pAvCodecCtx->extradata_size);
+		auto vSPSPPS = Platform::ArrayReference<uint8_t>(m_pAvCodecCtx->extradata, m_pAvCodecCtx->extradata_size);
 		dataWriter->WriteBytes(vSPSPPS);
 	}
 

--- a/FFmpegInterop/Source/MediaSampleProvider.cpp
+++ b/FFmpegInterop/Source/MediaSampleProvider.cpp
@@ -102,7 +102,7 @@ HRESULT MediaSampleProvider::WriteAVPacketToStream(DataWriter^ dataWriter, AVPac
 {
 	// This is the simplest form of transfer. Copy the packet directly to the stream
 	// This works for most compressed formats
-	auto aBuffer = ref new Platform::Array<uint8_t>(avPacket->data, avPacket->size);
+	auto aBuffer = Platform::ArrayReference<uint8_t>(avPacket->data, avPacket->size);
 	dataWriter->WriteBytes(aBuffer);
 	return S_OK;
 }

--- a/FFmpegInterop/Source/MediaSampleProvider.h
+++ b/FFmpegInterop/Source/MediaSampleProvider.h
@@ -50,7 +50,6 @@ namespace FFmpegInterop
 		int m_streamIndex;
 		int64 m_startOffset;
 		int64 m_nextFramePts;
-		bool m_isEnabled;
 
 	internal:
 		// The FFmpeg context. Because they are complex types
@@ -60,6 +59,7 @@ namespace FFmpegInterop
 		AVFormatContext* m_pAvFormatCtx;
 		AVCodecContext* m_pAvCodecCtx;
 		bool m_isDiscontinuous;
+		bool m_isEnabled;
 
 	internal:
 		MediaSampleProvider(

--- a/FFmpegInterop/Source/NativeBuffer.h
+++ b/FFmpegInterop/Source/NativeBuffer.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <wrl.h>
+#include <wrl/implements.h>
+#include <windows.storage.streams.h>
+#include <robuffer.h>
+#include <vector>
+
+namespace NativeBuffer
+{
+	class NativeBuffer :
+		public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
+		ABI::Windows::Storage::Streams::IBuffer,
+		Windows::Storage::Streams::IBufferByteAccess>
+	{
+	public:
+		virtual ~NativeBuffer()
+		{
+			if (m_free)
+			{
+				m_free(m_opaque);
+			}
+			m_pObject = nullptr;
+		}
+
+		STDMETHODIMP RuntimeClassInitialize(byte *buffer, UINT totalSize)
+		{
+			m_length = totalSize;
+			m_buffer = buffer;
+			m_free = NULL;
+			m_opaque = NULL;
+			m_pObject = nullptr;
+
+			return S_OK;
+		}
+
+		STDMETHODIMP RuntimeClassInitialize(byte *buffer, UINT totalSize, void(*free)(void *opaque), void *opaque)
+		{
+			m_length = totalSize;
+			m_buffer = buffer;
+			m_free = free;
+			m_opaque = opaque;
+			m_pObject = nullptr;
+
+			return S_OK;
+		}
+
+		STDMETHODIMP RuntimeClassInitialize(byte *buffer, UINT totalSize, Platform::Object^ pObject)
+		{
+			m_length = totalSize;
+			m_buffer = buffer;
+			m_free = NULL;
+			m_opaque = NULL;
+			m_pObject = pObject;
+
+			return S_OK;
+		}
+
+		STDMETHODIMP Buffer(byte **value)
+		{
+			*value = m_buffer;
+
+			return S_OK;
+		}
+
+		STDMETHODIMP get_Capacity(UINT32 *value)
+		{
+			*value = m_length;
+
+			return S_OK;
+		}
+
+		STDMETHODIMP get_Length(UINT32 *value)
+		{
+			*value = m_length;
+
+			return S_OK;
+		}
+
+		STDMETHODIMP put_Length(UINT32 value)
+		{
+			return E_FAIL;
+		}
+
+
+	private:
+		UINT32 m_length;
+		byte *m_buffer;
+		void(*m_free)(void *opaque);
+		void *m_opaque;
+		Platform::Object^ m_pObject;
+	};
+}

--- a/FFmpegInterop/Source/NativeBufferFactory.cpp
+++ b/FFmpegInterop/Source/NativeBufferFactory.cpp
@@ -1,0 +1,37 @@
+#include "pch.h"
+
+#include "NativeBuffer.h"
+#include "NativeBufferFactory.h"
+
+using namespace NativeBuffer;
+
+Windows::Storage::Streams::IBuffer^ NativeBufferFactory::CreateNativeBuffer(DWORD nNumberOfBytes)
+{
+	auto lpBuffer = (byte*)malloc(nNumberOfBytes);
+	return CreateNativeBuffer(lpBuffer, nNumberOfBytes, &free, lpBuffer);
+}
+
+Windows::Storage::Streams::IBuffer^ NativeBufferFactory::CreateNativeBuffer(LPVOID lpBuffer, DWORD nNumberOfBytes)
+{
+	return CreateNativeBuffer(lpBuffer, nNumberOfBytes, NULL, NULL);
+}
+
+Windows::Storage::Streams::IBuffer^ NativeBufferFactory::CreateNativeBuffer(LPVOID lpBuffer, DWORD nNumberOfBytes, void(*free)(void *opaque), void *opaque)
+{
+	Microsoft::WRL::ComPtr<NativeBuffer> nativeBuffer;
+	Microsoft::WRL::Details::MakeAndInitialize<NativeBuffer>(&nativeBuffer, (byte *)lpBuffer, nNumberOfBytes, free, opaque);
+	auto iinspectable = (IInspectable *)reinterpret_cast<IInspectable *>(nativeBuffer.Get());
+	Windows::Storage::Streams::IBuffer ^buffer = reinterpret_cast<Windows::Storage::Streams::IBuffer ^>(iinspectable);
+
+	return buffer;
+}
+
+Windows::Storage::Streams::IBuffer^ NativeBufferFactory::CreateNativeBuffer(LPVOID lpBuffer, DWORD nNumberOfBytes, Platform::Object^ pObject)
+{
+	Microsoft::WRL::ComPtr<NativeBuffer> nativeBuffer;
+	Microsoft::WRL::Details::MakeAndInitialize<NativeBuffer>(&nativeBuffer, (byte *)lpBuffer, nNumberOfBytes, pObject);
+	auto iinspectable = (IInspectable *)reinterpret_cast<IInspectable *>(nativeBuffer.Get());
+	Windows::Storage::Streams::IBuffer ^buffer = reinterpret_cast<Windows::Storage::Streams::IBuffer ^>(iinspectable);
+
+	return buffer;
+}

--- a/FFmpegInterop/Source/NativeBufferFactory.h
+++ b/FFmpegInterop/Source/NativeBufferFactory.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace NativeBuffer
+{
+	ref class NativeBufferFactory
+	{
+	internal:
+		static Windows::Storage::Streams::IBuffer ^CreateNativeBuffer(DWORD nNumberOfBytes);
+		static Windows::Storage::Streams::IBuffer ^CreateNativeBuffer(LPVOID lpBuffer, DWORD nNumberOfBytes);
+		static Windows::Storage::Streams::IBuffer ^CreateNativeBuffer(LPVOID lpBuffer, DWORD nNumberOfBytes, void(*free)(void *opaque), void *opaque);
+		static Windows::Storage::Streams::IBuffer ^CreateNativeBuffer(LPVOID lpBuffer, DWORD nNumberOfBytes, Platform::Object^ pObject);
+	};
+}

--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
@@ -98,7 +98,7 @@ HRESULT UncompressedAudioSampleProvider::ProcessDecodedFrame(DataWriter^ dataWri
 	uint8_t *resampledData = nullptr;
 	unsigned int aBufferSize = av_samples_alloc(&resampledData, NULL, m_pAvFrame->channels, m_pAvFrame->nb_samples, AV_SAMPLE_FMT_S16, 0);
 	int resampledDataSize = swr_convert(m_pSwrCtx, &resampledData, aBufferSize, (const uint8_t **)m_pAvFrame->extended_data, m_pAvFrame->nb_samples);
-	auto aBuffer = ref new Platform::Array<uint8_t>(resampledData, min(aBufferSize, (unsigned int)(resampledDataSize * m_pAvFrame->channels * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16))));
+	auto aBuffer = Platform::ArrayReference<uint8_t>(resampledData, min(aBufferSize, (unsigned int)(resampledDataSize * m_pAvFrame->channels * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16))));
 	dataWriter->WriteBytes(aBuffer);
 	av_freep(&resampledData);
 	av_frame_unref(m_pAvFrame);

--- a/FFmpegInterop/Source/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedVideoSampleProvider.cpp
@@ -18,6 +18,7 @@
 
 #include "pch.h"
 #include "UncompressedVideoSampleProvider.h"
+#include "NativeBufferFactory.h"
 #include <mfapi.h>
 
 extern "C"
@@ -25,37 +26,92 @@ extern "C"
 #include <libavutil/imgutils.h>
 }
 
-
 using namespace FFmpegInterop;
+using namespace NativeBuffer;
+using namespace Windows::Media::MediaProperties;
 
 UncompressedVideoSampleProvider::UncompressedVideoSampleProvider(
 	FFmpegReader^ reader,
 	AVFormatContext* avFormatCtx,
 	AVCodecContext* avCodecCtx)
 	: UncompressedSampleProvider(reader, avFormatCtx, avCodecCtx)
-	, m_pSwsCtx(nullptr)
 {
-	for (int i = 0; i < 4; i++)
+	switch (m_pAvCodecCtx->pix_fmt)
 	{
-		m_rgVideoBufferLineSize[i] = 0;
-		m_rgVideoBufferData[i] = nullptr;
+	case AV_PIX_FMT_YUV420P:
+		m_OutputPixelFormat = AV_PIX_FMT_YUV420P;
+		OutputMediaSubtype = MediaEncodingSubtypes::Iyuv;
+		break;
+	case AV_PIX_FMT_YUVJ420P:
+		m_OutputPixelFormat = AV_PIX_FMT_YUVJ420P;
+		OutputMediaSubtype = MediaEncodingSubtypes::Iyuv;
+		break;
+	case AV_PIX_FMT_YUVA420P:
+		m_OutputPixelFormat = AV_PIX_FMT_BGRA;
+		OutputMediaSubtype = MediaEncodingSubtypes::Argb32;
+		break;
+	default:
+		m_OutputPixelFormat = AV_PIX_FMT_NV12;
+		OutputMediaSubtype = MediaEncodingSubtypes::Nv12;
+		break;
 	}
+
+	// MPEG2 is often interlaced, and DXVA HW deinterlacing only works with NV12. Let's force output to NV12
+	if (m_pAvCodecCtx->codec_id == AV_CODEC_ID_MPEG2VIDEO || m_pAvCodecCtx->codec_id == AV_CODEC_ID_MPEG2VIDEO_XVMC)
+	{
+		m_OutputPixelFormat = AV_PIX_FMT_NV12;
+		OutputMediaSubtype = MediaEncodingSubtypes::Nv12;
+	}
+
+	auto width = avCodecCtx->width;
+	auto height = avCodecCtx->height;
+
+	if (m_pAvCodecCtx->pix_fmt == m_OutputPixelFormat)
+	{
+		if (m_pAvCodecCtx->codec->capabilities & AV_CODEC_CAP_DR1)
+		{
+			// This codec supports direct buffer decoding.
+			// Get decoder frame size and override get_buffer2...
+			avcodec_align_dimensions(m_pAvCodecCtx, &width, &height);
+
+			m_pAvCodecCtx->get_buffer2 = get_buffer2;
+			m_pAvCodecCtx->opaque = (void*)this;
+		}
+		else
+		{
+			// We cannot use direct buffer decoding with this codec.
+			// Now that we must use scaler, let's directly scale to NV12.
+			if (m_OutputPixelFormat == AV_PIX_FMT_YUV420P || m_OutputPixelFormat == AV_PIX_FMT_YUVJ420P)
+			{
+				m_OutputPixelFormat = AV_PIX_FMT_NV12;
+				OutputMediaSubtype = MediaEncodingSubtypes::Nv12;
+			}
+			m_bUseScaler = true;
+		}
+	}
+	else
+	{
+		// Scaler required to convert pixel format
+		m_bUseScaler = true;
+	}
+
+	DecoderWidth = width;
+	DecoderHeight = height;
 }
 
-HRESULT UncompressedVideoSampleProvider::AllocateResources()
+HRESULT UncompressedVideoSampleProvider::InitializeScalerIfRequired()
 {
 	HRESULT hr = S_OK;
-	hr = UncompressedSampleProvider::AllocateResources();
-	if (SUCCEEDED(hr))
+	if (m_bUseScaler && !m_pSwsCtx)
 	{
-		// Setup software scaler to convert any decoder pixel format (e.g. YUV420P) to NV12 that is supported in Windows & Windows Phone MediaElement
+		// Setup software scaler to convert frame to output pixel type
 		m_pSwsCtx = sws_getContext(
 			m_pAvCodecCtx->width,
 			m_pAvCodecCtx->height,
 			m_pAvCodecCtx->pix_fmt,
 			m_pAvCodecCtx->width,
 			m_pAvCodecCtx->height,
-			AV_PIX_FMT_NV12,
+			m_OutputPixelFormat,
 			SWS_BICUBIC,
 			NULL,
 			NULL,
@@ -64,23 +120,6 @@ HRESULT UncompressedVideoSampleProvider::AllocateResources()
 		if (m_pSwsCtx == nullptr)
 		{
 			hr = E_OUTOFMEMORY;
-		}
-	}
-
-	if (SUCCEEDED(hr))
-	{
-		m_pAvFrame = av_frame_alloc();
-		if (m_pAvFrame == nullptr)
-		{
-			hr = E_OUTOFMEMORY;
-		}
-	}
-
-	if (SUCCEEDED(hr))
-	{
-		if (av_image_alloc(m_rgVideoBufferData, m_rgVideoBufferLineSize, m_pAvCodecCtx->width, m_pAvCodecCtx->height, AV_PIX_FMT_NV12, 1) < 0)
-		{
-			hr = E_FAIL;
 		}
 	}
 
@@ -94,9 +133,19 @@ UncompressedVideoSampleProvider::~UncompressedVideoSampleProvider()
 		av_frame_free(&m_pAvFrame);
 	}
 
-	if (m_rgVideoBufferData)
+	if (m_pSwsCtx)
 	{
-		av_freep(m_rgVideoBufferData);
+		sws_freeContext(m_pSwsCtx);
+	}
+
+	if (m_pBufferPool)
+	{
+		av_buffer_pool_uninit(&m_pBufferPool);
+	}
+
+	if (m_pDirectBuffer)
+	{
+		m_pDirectBuffer = nullptr;
 	}
 }
 
@@ -119,19 +168,45 @@ HRESULT UncompressedVideoSampleProvider::DecodeAVPacket(DataWriter^ dataWriter, 
 
 MediaStreamSample^ UncompressedVideoSampleProvider::GetNextSample()
 {
-	MediaStreamSample^ sample = MediaSampleProvider::GetNextSample();
+	DebugMessage(L"GetNextSample\n");
 
-	if (sample != nullptr)
+	HRESULT hr = S_OK;
+
+	MediaStreamSample^ sample;
+	if (m_isEnabled)
 	{
-		if (m_interlaced_frame)
+		LONGLONG pts = 0;
+		LONGLONG dur = 0;
+
+		hr = GetNextPacket(nullptr, pts, dur, true);
+
+		if (hr == S_OK && !m_pDirectBuffer)
 		{
-			sample->ExtendedProperties->Insert(MFSampleExtension_Interlaced, TRUE);
-			sample->ExtendedProperties->Insert(MFSampleExtension_BottomFieldFirst, m_top_field_first ? safe_cast<Platform::Object^>(FALSE) : TRUE);
-			sample->ExtendedProperties->Insert(MFSampleExtension_RepeatFirstField, safe_cast<Platform::Object^>(FALSE));
+			hr = E_FAIL;
+		}
+
+		if (hr == S_OK)
+		{
+			sample = MediaStreamSample::CreateFromBuffer(m_pDirectBuffer, { pts });
+			sample->Duration = { dur };
+			sample->Discontinuous = m_isDiscontinuous;
+			if (m_interlaced_frame)
+			{
+				sample->ExtendedProperties->Insert(MFSampleExtension_Interlaced, TRUE);
+				sample->ExtendedProperties->Insert(MFSampleExtension_BottomFieldFirst, m_top_field_first ? safe_cast<Platform::Object^>(FALSE) : TRUE);
+				sample->ExtendedProperties->Insert(MFSampleExtension_RepeatFirstField, safe_cast<Platform::Object^>(FALSE));
+			}
+			else
+			{
+				sample->ExtendedProperties->Insert(MFSampleExtension_Interlaced, safe_cast<Platform::Object^>(FALSE));
+			}
+			m_isDiscontinuous = false;
+			m_pDirectBuffer = nullptr;
 		}
 		else
 		{
-			sample->ExtendedProperties->Insert(MFSampleExtension_Interlaced, safe_cast<Platform::Object^>(FALSE));
+			DebugMessage(L"Too many broken packets - disable stream\n");
+			DisableStream();
 		}
 	}
 
@@ -140,18 +215,119 @@ MediaStreamSample^ UncompressedVideoSampleProvider::GetNextSample()
 
 HRESULT UncompressedVideoSampleProvider::WriteAVPacketToStream(DataWriter^ dataWriter, AVPacket* avPacket)
 {
-	// Convert decoded video pixel format to NV12 using FFmpeg software scaler
-	if (sws_scale(m_pSwsCtx, (const uint8_t **)(m_pAvFrame->data), m_pAvFrame->linesize, 0, m_pAvCodecCtx->height, m_rgVideoBufferData, m_rgVideoBufferLineSize) < 0)
+	auto hr = InitializeScalerIfRequired();
+
+	if (SUCCEEDED(hr))
+	{
+		if (!m_bUseScaler)
+		{
+			// Using direct buffer: just create a buffer reference to hand out to MSS pipeline
+			auto bufferRef = av_buffer_ref(m_pAvFrame->buf[0]);
+			if (bufferRef)
+			{
+				m_pDirectBuffer = NativeBufferFactory::CreateNativeBuffer(bufferRef->data, bufferRef->size, free_buffer, bufferRef);
+			}
+			else
+			{
+				hr = E_FAIL;
+			}
+		}
+		else
+		{
+			// Using scaler: allocate a new frame from buffer pool
+			auto frame = ref new FrameDataHolder();
+			hr = FillLinesAndBuffer(frame->linesize, frame->data, &frame->buffer);
+			if (SUCCEEDED(hr))
+			{
+				// Convert to output format using FFmpeg software scaler
+				if (sws_scale(m_pSwsCtx, (const uint8_t **)(m_pAvFrame->data), m_pAvFrame->linesize, 0, m_pAvCodecCtx->height, frame->data, frame->linesize) > 0)
+				{
+					m_pDirectBuffer = NativeBufferFactory::CreateNativeBuffer(frame->buffer->data, frame->buffer->size, free_buffer, frame->buffer);
+				}
+				else
+				{
+					free_buffer(frame->buffer);
+					hr = E_FAIL;
+				}
+			}
+		}
+	}
+
+	av_frame_unref(m_pAvFrame);
+	av_frame_free(&m_pAvFrame);
+
+	return hr;
+}
+
+HRESULT UncompressedVideoSampleProvider::FillLinesAndBuffer(int* linesize, byte** data, AVBufferRef** buffer)
+{
+	if (av_image_fill_linesizes(linesize, m_OutputPixelFormat, DecoderWidth) < 0)
 	{
 		return E_FAIL;
 	}
 
-	auto YBuffer = ref new Platform::Array<uint8_t>(m_rgVideoBufferData[0], m_rgVideoBufferLineSize[0] * m_pAvCodecCtx->height);
-	auto UVBuffer = ref new Platform::Array<uint8_t>(m_rgVideoBufferData[1], m_rgVideoBufferLineSize[1] * m_pAvCodecCtx->height / 2);
-	dataWriter->WriteBytes(YBuffer);
-	dataWriter->WriteBytes(UVBuffer);
-	av_frame_unref(m_pAvFrame);
-	av_frame_free(&m_pAvFrame);
+	auto YBufferSize = linesize[0] * DecoderHeight;
+	auto UBufferSize = linesize[1] * DecoderHeight / 2;
+	auto VBufferSize = linesize[2] * DecoderHeight / 2;
+	auto totalSize = YBufferSize + UBufferSize + VBufferSize;
+
+	buffer[0] = AllocateBuffer(totalSize);
+	if (!buffer[0])
+	{
+		return E_OUTOFMEMORY;
+	}
+
+	data[0] = buffer[0]->data;
+	data[1] = UBufferSize > 0 ? buffer[0]->data + YBufferSize : NULL;
+	data[2] = VBufferSize > 0 ? buffer[0]->data + YBufferSize + UBufferSize : NULL;
+	data[3] = NULL;
 
 	return S_OK;
+}
+
+AVBufferRef* UncompressedVideoSampleProvider::AllocateBuffer(int totalSize)
+{
+	if (!m_pBufferPool)
+	{
+		m_pBufferPool = av_buffer_pool_init(totalSize, NULL);
+		if (!m_pBufferPool)
+		{
+			return NULL;
+		}
+	}
+
+	auto buffer = av_buffer_pool_get(m_pBufferPool);
+	if (!buffer)
+	{
+		return NULL;
+	}
+	if (buffer->size != totalSize)
+	{
+		free_buffer(buffer);
+		return NULL;
+	}
+
+	return buffer;
+}
+
+void UncompressedVideoSampleProvider::free_buffer(void *lpVoid)
+{
+	auto buffer = (AVBufferRef *)lpVoid;
+	auto count = av_buffer_get_ref_count(buffer);
+	av_buffer_unref(&buffer);
+}
+
+int UncompressedVideoSampleProvider::get_buffer2(AVCodecContext *avCodecContext, AVFrame *frame, int flags)
+{
+	// If frame size changes during playback and gets larger than our buffer, we need to switch to sws_scale
+	auto provider = reinterpret_cast<UncompressedVideoSampleProvider^>(avCodecContext->opaque);
+	provider->m_bUseScaler = frame->height > provider->DecoderHeight || frame->width > provider->DecoderWidth;
+	if (provider->m_bUseScaler)
+	{
+		return avcodec_default_get_buffer2(avCodecContext, frame, flags);
+	}
+	else
+	{
+		return provider->FillLinesAndBuffer(frame->linesize, frame->data, frame->buf);
+	}
 }

--- a/FFmpegInterop/Win10/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/Win10/FFmpegInterop/FFmpegInterop.vcxproj
@@ -234,6 +234,8 @@
     <ClInclude Include="..\..\Source\ILogProvider.h" />
     <ClInclude Include="..\..\Source\MediaSampleProvider.h" />
     <ClInclude Include="..\..\Source\MediaThumbnailData.h" />
+    <ClInclude Include="..\..\Source\NativeBuffer.h" />
+    <ClInclude Include="..\..\Source\NativeBufferFactory.h" />
     <ClInclude Include="..\..\Source\UncompressedAudioSampleProvider.h" />
     <ClInclude Include="..\..\Source\UncompressedSampleProvider.h" />
     <ClInclude Include="..\..\Source\UncompressedVideoSampleProvider.h" />
@@ -246,6 +248,7 @@
     <ClCompile Include="..\..\Source\H264AVCSampleProvider.cpp" />
     <ClCompile Include="..\..\Source\H264SampleProvider.cpp" />
     <ClCompile Include="..\..\Source\MediaSampleProvider.cpp" />
+    <ClCompile Include="..\..\Source\NativeBufferFactory.cpp" />
     <ClCompile Include="..\..\Source\UncompressedAudioSampleProvider.cpp" />
     <ClCompile Include="..\..\Source\UncompressedSampleProvider.cpp" />
     <ClCompile Include="..\..\Source\UncompressedVideoSampleProvider.cpp" />

--- a/FFmpegInterop/Win10/FFmpegInterop/FFmpegInterop.vcxproj.filters
+++ b/FFmpegInterop/Win10/FFmpegInterop/FFmpegInterop.vcxproj.filters
@@ -17,6 +17,7 @@
     <ClCompile Include="..\..\Source\UncompressedSampleProvider.cpp" />
     <ClCompile Include="..\..\Source\UncompressedVideoSampleProvider.cpp" />
     <ClCompile Include="..\..\Source\FFmpegInteropLogging.cpp" />
+    <ClCompile Include="..\..\Source\NativeBufferFactory.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -32,5 +33,7 @@
     <ClInclude Include="..\..\Source\FFmpegInteropLogging.h" />
     <ClInclude Include="..\..\Source\MediaThumbnailData.h" />
     <ClInclude Include="..\..\Source\CritSec.h" />
+    <ClInclude Include="..\..\Source\NativeBuffer.h" />
+    <ClInclude Include="..\..\Source\NativeBufferFactory.h" />
   </ItemGroup>
 </Project>

--- a/FFmpegInterop/Win8.1/FFmpegInterop.Shared/FFmpegInterop.Shared.vcxitems
+++ b/FFmpegInterop/Win8.1/FFmpegInterop.Shared/FFmpegInterop.Shared.vcxitems
@@ -22,6 +22,8 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\H264SampleProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\ILogProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\MediaSampleProvider.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\NativeBuffer.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\NativeBufferFactory.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedAudioSampleProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedSampleProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedVideoSampleProvider.h" />
@@ -34,6 +36,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\H264AVCSampleProvider.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\H264SampleProvider.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\MediaSampleProvider.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\NativeBufferFactory.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedAudioSampleProvider.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedSampleProvider.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedVideoSampleProvider.cpp" />

--- a/FFmpegInterop/Win8.1/FFmpegInterop.Shared/FFmpegInterop.Shared.vcxitems.filters
+++ b/FFmpegInterop/Win8.1/FFmpegInterop.Shared/FFmpegInterop.Shared.vcxitems.filters
@@ -7,6 +7,8 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\FFmpegReader.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\H264SampleProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\MediaSampleProvider.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\NativeBuffer.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\NativeBufferFactory.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedAudioSampleProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedSampleProvider.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedVideoSampleProvider.h" />
@@ -22,6 +24,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\FFmpegReader.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\H264SampleProvider.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\MediaSampleProvider.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\NativeBufferFactory.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedAudioSampleProvider.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedSampleProvider.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\UncompressedVideoSampleProvider.cpp" />


### PR DESCRIPTION
This PR further improves video decoding performance over #204 by eliminating all unneccessary copy operations. Decoder (or scaler, if required) will directly render into output buffer. BufferPool is used to keep memory usage stable (as opposed to allocating new memory for every frame).

If a frame size change is detected which exceeds the direct decoding buffer size, the solution automatically switches to scaler. I don't have any file to test this, but I think it could happen on broadcasts or maybe also incorrectly merged files.

One more thing I noticed: When we use Iyuv output, the DXVA hardware deinterlacer does not work, making interlaced mpeg2 files look a bit worse (e.g. the simpsons file). So I added code to enforce nv12 output for mpeg2. Hope this is a good idea.