### PR TITLE
Dcarpente/uncompressed audio duration

### DIFF
--- a/FFmpegInterop/Source/MediaSampleProvider.h
+++ b/FFmpegInterop/Source/MediaSampleProvider.h
@@ -47,7 +47,6 @@ namespace FFmpegInterop
 
 	private:
 		std::vector<AVPacket> m_packetQueue;
-		int m_streamIndex;
 		int64 m_startOffset;
 		int64 m_nextFramePts;
 		bool m_isEnabled;
@@ -60,6 +59,7 @@ namespace FFmpegInterop
 		AVFormatContext* m_pAvFormatCtx;
 		AVCodecContext* m_pAvCodecCtx;
 		bool m_isDiscontinuous;
+		int m_streamIndex;
 
 	internal:
 		MediaSampleProvider(

--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
@@ -146,14 +146,14 @@ MediaStreamSample^ UncompressedAudioSampleProvider::GetNextSample()
 
 	} while (SUCCEEDED(hr) && finalDur < MINAUDIOSAMPLEDURATION);
 
-	if (finalDur > 0)
+	if (finalPts != -1)
 	{
 		sample = MediaStreamSample::CreateFromBuffer(dataWriter->DetachBuffer(), { finalPts });
 
 		// Recalculate duration after appending samples
 		// FFMPEG does not seem to always output correct duration for uncompressed
-		LONGLONG numerator = sample->Buffer->Length * 10000000LL;
-		LONGLONG denominator = m_pAvFormatCtx->streams[m_streamIndex]->codecpar->channels * m_pAvFormatCtx->streams[m_streamIndex]->codecpar->sample_rate * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16);
+		const LONGLONG numerator = sample->Buffer->Length * 10000000LL;
+		const LONGLONG denominator = m_pAvFormatCtx->streams[m_streamIndex]->codecpar->channels * m_pAvFormatCtx->streams[m_streamIndex]->codecpar->sample_rate * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16);
 		if (denominator != 0)
 		{
 			sample->Duration = { numerator / denominator };

--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
@@ -152,8 +152,8 @@ MediaStreamSample^ UncompressedAudioSampleProvider::GetNextSample()
 
 		// Recalculate duration after appending samples
 		// FFMPEG does not seem to always output correct duration for uncompressed
-		LONGLONG numerator = sample->Buffer->Length * 10000000;
-		LONGLONG denominator = m_pAvFormatCtx->streams[m_streamIndex]->codecpar->channels * m_pAvFormatCtx->streams[m_streamIndex]->codecpar->sample_rate * m_pAvFormatCtx->streams[m_streamIndex]->codecpar->bit_rate;
+		LONGLONG numerator = sample->Buffer->Length * 10000000LL;
+		LONGLONG denominator = m_pAvFormatCtx->streams[m_streamIndex]->codecpar->channels * m_pAvFormatCtx->streams[m_streamIndex]->codecpar->sample_rate * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16);
 		sample->Duration = { numerator / denominator };
 
 		sample->Discontinuous = isDiscontinuous;

--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
@@ -154,7 +154,10 @@ MediaStreamSample^ UncompressedAudioSampleProvider::GetNextSample()
 		// FFMPEG does not seem to always output correct duration for uncompressed
 		LONGLONG numerator = sample->Buffer->Length * 10000000LL;
 		LONGLONG denominator = m_pAvFormatCtx->streams[m_streamIndex]->codecpar->channels * m_pAvFormatCtx->streams[m_streamIndex]->codecpar->sample_rate * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16);
-		sample->Duration = { numerator / denominator };
+		if (denominator != 0)
+		{
+			sample->Duration = { numerator / denominator };
+		}
 
 		sample->Discontinuous = isDiscontinuous;
 		if (SUCCEEDED(hr))

--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
@@ -25,9 +25,6 @@ using namespace FFmpegInterop;
 // Minimum duration for uncompressed audio samples (50 ms)
 const LONGLONG MINAUDIOSAMPLEDURATION = 500000;
 
-// Maximum duration for uncompressed audio samples (50000 ms = 50 sec)
-const LONGLONG MAXAUDIOSAMPLEDURATION = 500000000;
-
 UncompressedAudioSampleProvider::UncompressedAudioSampleProvider(
 	FFmpegReader^ reader,
 	AVFormatContext* avFormatCtx,


### PR DESCRIPTION
This changes UncompressedAudioSampleProvider to recalculate sample duration at the end of ProcessDecodedFrame method. 

GetNextPacket uses duration on AVPacket, but we were seeing some cases where the value would be incorrect/extremely high. Repro case: Vorbis in OGG content through WebAudio API at http://lol.disney.com/games/descendants-2-mal-vs-uma