### PR TITLE
Dcarpente/mss handle test

### DIFF
--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -62,30 +62,14 @@ static int lock_manager(void **mtx, enum AVLockOp op);
 // Flag for ffmpeg global setup
 static bool isRegistered = false;
 
-void FFmpegInterop::FFmpegInteropMSS::ReleaseObjects()
+void FFmpegInterop::FFmpegInteropMSS::ReleaseFileStream()
 {
 	mutexGuard.lock();
 	if (fileStreamData != nullptr)
 	{
 		fileStreamData->Release();
+		fileStreamData = nullptr;
 	}
-	
-	// Clear our data
-	audioSampleProvider = nullptr;
-	videoSampleProvider = nullptr;
-
-	if (m_pReader != nullptr)
-	{
-		m_pReader->SetAudioStream(AVERROR_STREAM_NOT_FOUND, nullptr);
-		m_pReader->SetVideoStream(AVERROR_STREAM_NOT_FOUND, nullptr);
-		m_pReader = nullptr;
-	}
-	
-	avcodec_close(avVideoCodecCtx);
-	avcodec_close(avAudioCodecCtx);
-	avformat_close_input(&avFormatCtx);
-	av_free(avIOCtx);
-	av_dict_free(&avDict);
 
 	mutexGuard.unlock();
 }
@@ -115,6 +99,7 @@ FFmpegInteropMSS::~FFmpegInteropMSS()
 	if (fileStreamData != nullptr)
 	{
 		fileStreamData->Release();
+		fileStreamData = nullptr;
 	}
 
 	// Clear our data

--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -96,10 +96,11 @@ FFmpegInteropMSS::FFmpegInteropMSS()
 FFmpegInteropMSS::~FFmpegInteropMSS()
 {
 	mutexGuard.lock();
-	if (fileStreamData != nullptr)
+	if (mss)
 	{
-		fileStreamData->Release();
-		fileStreamData = nullptr;
+		mss->Starting -= startingRequestedToken;
+		mss->SampleRequested -= sampleRequestedToken;
+		mss = nullptr;
 	}
 
 	// Clear our data
@@ -118,14 +119,11 @@ FFmpegInteropMSS::~FFmpegInteropMSS()
 	avformat_close_input(&avFormatCtx);
 	av_free(avIOCtx);
 	av_dict_free(&avDict);
-
-	if (mss)
+	if (fileStreamData != nullptr)
 	{
-		mss->Starting -= startingRequestedToken;
-		mss->SampleRequested -= sampleRequestedToken;
-		mss = nullptr;
+		fileStreamData->Release();
+		fileStreamData = nullptr;
 	}
-
 	mutexGuard.unlock();
 }
 

--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -119,6 +119,7 @@ FFmpegInteropMSS::~FFmpegInteropMSS()
 	avformat_close_input(&avFormatCtx);
 	av_free(avIOCtx);
 	av_dict_free(&avDict);
+
 	if (fileStreamData != nullptr)
 	{
 		fileStreamData->Release();

--- a/FFmpegInterop/Source/FFmpegInteropMSS.h
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.h
@@ -86,7 +86,7 @@ namespace FFmpegInterop
 			};
 		};
 
-		void ReleaseObjects();
+		void ReleaseFileStream();
 
 	internal:
 		int ReadPacket();

--- a/FFmpegInterop/Source/FFmpegInteropMSS.h
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.h
@@ -86,6 +86,8 @@ namespace FFmpegInterop
 			};
 		};
 
+		void ReleaseObjects();
+
 	internal:
 		int ReadPacket();
 


### PR DESCRIPTION
Need to have an option to release just the filestream but not the complete deconstruction.