### PR TITLE
Fix stream start offset logic

### DIFF
--- a/FFmpegInterop/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/FFmpegInteropMSS.cpp
@@ -784,7 +784,8 @@ void FFmpegInteropMSS::OnStarting(MediaStreamSource ^sender, MediaStreamSourceSt
 		if (streamIndex >= 0)
 		{
 			// Convert TimeSpan unit to AV_TIME_BASE
-			int64_t seekTarget = static_cast<int64_t>(request->StartPosition->Value.Duration / (av_q2d(avFormatCtx->streams[streamIndex]->time_base) * 10000000));
+			int64_t startOffset = (avFormatCtx->start_time != AV_NOPTS_VALUE) ? static_cast<int64_t>(avFormatCtx->start_time * 10000000 / double(AV_TIME_BASE)) : 0;
+			int64_t seekTarget = static_cast<int64_t>((startOffset + request->StartPosition->Value.Duration) / (av_q2d(avFormatCtx->streams[streamIndex]->time_base) * 10000000));
 
 			if (av_seek_frame(avFormatCtx, streamIndex, seekTarget, AVSEEK_FLAG_BACKWARD) < 0)
 			{


### PR DESCRIPTION
The current sample presentation time stamp logic forces the first sample for all streams to be at time 0. This causes synchronization issues when streams don't start at the same time. For example, the first sample for a subtitle stream may not have the same timestamp as the first sample for the audio stream and forcing both streams to start at time 0 causes all of the subtitles to be out of sync with the audio.

This change addresses this issue by using AVFormatContext::start_time as the stream start offset when calculating sample presentation time stamps.