### PR TITLE
Seek time validation check incorrectly failing for file with large start time offset

### DIFF
--- a/FFmpegInterop/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/FFmpegInteropMSS.cpp
@@ -360,6 +360,7 @@ namespace winrt::FFmpegInterop::implementation
 			{
 				// Convert the seek time from HNS to AV_TIME_BASE
 				int64_t avSeekTime{ ConvertToAVTime(hnsSeekTime.count(), HNS_PER_SEC, av_get_time_base_q()) };
+				THROW_HR_IF(MF_E_INVALID_TIMESTAMP, avSeekTime > m_formatContext->duration);
 
 				if (m_formatContext->start_time != AV_NOPTS_VALUE)
 				{
@@ -367,7 +368,6 @@ namespace winrt::FFmpegInterop::implementation
 					avSeekTime += m_formatContext->start_time;
 				}
 
-				THROW_HR_IF(MF_E_INVALID_TIMESTAMP, avSeekTime > m_formatContext->duration);
 				THROW_HR_IF_FFMPEG_FAILED(avformat_seek_file(m_formatContext.get(), -1, numeric_limits<int64_t>::min(), avSeekTime, avSeekTime, 0));
 
 				for (auto& [streamId, stream] : m_streamIdMap)


### PR DESCRIPTION
In FFmpegInteropMSS::OnStarting() we have a sanity check to verify that the seek time doesn’t exceed the duration. However, the duration is start-time-based while the seek time is zero-based  having already taken into account the start time offset. This can cause the check to incorrectly fail when the start time is not zero.

For example it's possible for a file’s start time to be larger than its duration. In this case the validation check will always fail since the seek time will always be greater than the duration.

This change moves the validation check prior to adjusting the seek time by the start time offset (i.e. when seek time is start-time-based like the duration).