### PR TITLE
Set codec parameters from FLAC stream info in FLACSampleProvider

### DIFF
--- a/FFmpegInterop/BitstreamReader.cpp
+++ b/FFmpegInterop/BitstreamReader.cpp
@@ -60,7 +60,7 @@ namespace winrt::FFmpegInterop::implementation
 
 	uint32_t BitstreamReader::ReadN(_In_range_(<=, 32) uint32_t numBitsToRead)
 	{
-		WINRT_ASSERT(numBitsToRead <= 32);
+		THROW_HR_IF(E_INVALIDARG, numBitsToRead > 32);
 
 		// Make sure we have enough data left to fulfill the read request
 		THROW_HR_IF(MF_E_INVALID_POSITION, numBitsToRead > BitsRemaining());

--- a/FFmpegInterop/BitstreamReader.h
+++ b/FFmpegInterop/BitstreamReader.h
@@ -28,6 +28,7 @@ namespace winrt::FFmpegInterop::implementation
 		void SkipN(_In_ uint32_t numBits);
 		void SkipExpGolomb();
 
+		uint32_t ReadN(_In_range_(<= , 32) uint32_t numBitsToRead);
 		bool Read1() { return static_cast<bool>(ReadN(1)); }
 		uint8_t Read8() { return static_cast<uint8_t>(ReadN(8)); }
 		uint16_t Read16() { return static_cast<uint16_t>(ReadN(16)); }
@@ -37,7 +38,6 @@ namespace winrt::FFmpegInterop::implementation
 
 	private:
 		size_t BitsRemaining() const noexcept;
-		uint32_t ReadN(_In_range_(<= , 32) uint32_t numBitsToRead);
 
 		const uint8_t* m_data{ nullptr };
 		uint32_t m_dataSize{ 0 };

--- a/FFmpegInterop/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/FFmpegInteropMSS.cpp
@@ -220,7 +220,7 @@ namespace winrt::FFmpegInterop::implementation
 			case AVMEDIA_TYPE_AUDIO:
 				tie(sampleProvider, streamDescriptor) = StreamFactory::CreateAudioStream(m_formatContext.get(), stream, m_reader, config);
 
-				if (hasAudio || i == preferredAudioStreamId)
+				if (hasAudio || preferredAudioStreamId == i || preferredAudioStreamId < 0)
 				{
 					// Add the stream to the MSS
 					m_mss.AddStreamDescriptor(streamDescriptor);
@@ -256,7 +256,7 @@ namespace winrt::FFmpegInterop::implementation
 
 				tie(sampleProvider, streamDescriptor) = StreamFactory::CreateVideoStream(m_formatContext.get(), stream, m_reader, config);
 
-				if (hasVideo || i == preferredVideoStreamId)
+				if (hasVideo || preferredVideoStreamId == i || preferredVideoStreamId < 0)
 				{
 					// Add the stream to the MSS
 					m_mss.AddStreamDescriptor(streamDescriptor);
@@ -314,6 +314,9 @@ namespace winrt::FFmpegInterop::implementation
 			m_streamIdMap[i] = sampleProvider.get();
 			m_streamDescriptorMap[move(streamDescriptor)] = move(sampleProvider);
 		}
+
+		WINRT_ASSERT(pendingAudioStreamDescriptors.empty());
+		WINRT_ASSERT(pendingVideoStreamDescriptors.empty());
 
 		if (m_formatContext->duration > 0)
 		{

--- a/FFmpegInterop/FLACSampleProvider.h
+++ b/FFmpegInterop/FLACSampleProvider.h
@@ -30,5 +30,11 @@ namespace winrt::FFmpegInterop::implementation
 
 	protected:
 		std::tuple<Windows::Storage::Streams::IBuffer, int64_t, int64_t, std::vector<std::pair<GUID, Windows::Foundation::IInspectable>>, std::vector<std::pair<GUID, Windows::Foundation::IInspectable>>> GetSampleData() override;
+	
+		static constexpr uint32_t FLAC_STREAMINFO_SIZE{ 34 };
+		static constexpr std::array<uint8_t, 4> FLAC_MARKER{ 'f', 'L', 'a', 'C' };
+		static constexpr std::array<uint8_t, 4> FLAC_STREAMINFO_HEADER{ 0x80, 0x00, 0x00, 0x22 };
+
+		_Field_size_(FLAC_STREAMINFO_SIZE) const uint8_t* m_flacStreamInfo{ nullptr };
 	};
 }


### PR DESCRIPTION
When FFmpeg is built without the FLAC decoder, some fields (e.g. channels, sample rate, bit rate) may not be set on the stream's codec parameters which can cause playback to fail.

This change updates the FLACSampleProvider to parse the FLAC stream info in the codec private data and set the stream's codec parameters accordingly.