### PR TITLE
Don't buffer packets for deselected streams

### DIFF
--- a/FFmpegInterop/SampleProvider.cpp
+++ b/FFmpegInterop/SampleProvider.cpp
@@ -331,8 +331,10 @@ namespace winrt::FFmpegInterop::implementation
 
 	void SampleProvider::QueuePacket(_In_ AVPacket_ptr packet)
 	{
-		WINRT_ASSERT(m_isSelected);
-		m_packetQueue.push_back(move(packet));
+		if (m_isSelected)
+		{
+			m_packetQueue.push_back(move(packet));
+		}
 	}
 
 	void SampleProvider::GetSample(_Inout_ const MediaStreamSourceSampleRequest& request)


### PR DESCRIPTION
For deselected streams we set AVStream::discard to AVDISCARD_ALL. However, read_frame_internal() only honors this flag and discard packets when parsing is needed (AVStream::need_parsing && AVStream::parser). It's unclear to me whether this is a bug or the desired behavior. In any case, this violates the assertion in SampleProvider::QueuePacket() that we don't queue packets for deselected streams.

I changed the assertion in SampleProvider::QueuePacket() to a hard check so that we don't unnecessarily buffer packets for deselected streams.