### PR TITLE
Use /PROFILE linker option for building FFmpeg binaries

### DIFF
--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -11,7 +11,7 @@ common_settings=" \
     --enable-shared \
     --enable-cross-compile \
     --extra-cflags=\"-MD -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WIN32_WINNT=0x0A00\" \
-    --extra-ldflags=\"-APPCONTAINER WindowsApp.lib\" \
+    --extra-ldflags=\"-APPCONTAINER WindowsApp.lib -PROFILE\" \
     "
 
 # Architecture specific configure settings


### PR DESCRIPTION
This change updates FFmpegConfig.sh to build FFmpeg with the [/PROFILE linker option](https://docs.microsoft.com/en-us/cpp/build/reference/profile-performance-tools-profiler?view=msvc-160) set. This is required for Microsoft's APIscan tool.