### PR TITLE
MSFT: 31595456 - Add MediaStreamSource.Closed event handler

### DIFF
--- a/FFmpegInterop/FFmpegInteropMSS.h
+++ b/FFmpegInterop/FFmpegInteropMSS.h
@@ -100,7 +100,7 @@ namespace FFmpegInterop
 			};
 		};
 
-		void ReleaseFileStream();
+		void Shutdown();
 
 	internal:
 		int ReadPacket();
@@ -120,11 +120,13 @@ namespace FFmpegInterop
 		void OnStarting(MediaStreamSource ^sender, MediaStreamSourceStartingEventArgs ^args);
 		void OnSampleRequested(MediaStreamSource ^sender, MediaStreamSourceSampleRequestedEventArgs ^args);
 		void OnSwitchStreamsRequested(MediaStreamSource ^sender, MediaStreamSourceSwitchStreamsRequestedEventArgs ^args);
+		void OnClosed(MediaStreamSource^ sender, MediaStreamSourceClosedEventArgs^ args);
 
 		MediaStreamSource^ mss;
 		EventRegistrationToken startingRequestedToken;
 		EventRegistrationToken sampleRequestedToken;
 		EventRegistrationToken switchStreamsRequestedToken;
+		EventRegistrationToken closedToken;
 
 	internal:
 		AVDictionary* avDict;


### PR DESCRIPTION
This change adds a [MediaStreamSource.Closed](https://docs.microsoft.com/en-us/uwp/api/windows.media.core.mediastreamsource.closed) event handler to the FFmpegInteropMSS. This enables us to free resources as soon as possible instead of waiting until destruction.