### PR TITLE
MSFT: 32158630 - Update debug builds to use /DEBUG:FULL linker option for better WinDbg debugging experience

### DIFF
--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -92,6 +92,9 @@
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <Link>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -81,6 +81,9 @@
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <Link>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>


### PR DESCRIPTION
WinDbgX has limited support for PDBs generated using the /DEBUG:FASTLINK linker option which is the default in VS2017+. For example, wild card symbol searches (x FFmpegInterop!*FFmpegInteropMSS::OnStarting) don't work.

This change updates debug builds to use the /DEBUG:FULL linker option for a better WinDbgX debugging experience.

[/DEBUG (Generate Debug Info) | Microsoft Docs](https://docs.microsoft.com/en-us/cpp/build/reference/debug-generate-debug-info)