### PR TITLE
MSFT: 26268644 - Add version adaptive logic and lower min supported version

### DIFF
--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -36,7 +36,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/FFmpegInterop/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/FFmpegInteropMSS.cpp
@@ -519,30 +519,35 @@ HRESULT FFmpegInteropMSS::InitFFmpegContext(bool forceAudioDecode, bool forceVid
 
 	if (SUCCEEDED(hr))
 	{
-		// Get the subtitle stream
-		for (unsigned int i = 0; i < avFormatCtx->nb_streams; i++)
+		// Subtitle streams use TimedMetadataStreamDescriptor which was added in 17134. Check if this type is present.
+		// Note: MSS didn't expose subtitle streams in media engine scenarios until 19041.
+		if (Windows::Foundation::Metadata::ApiInformation::IsTypePresent(L"Windows.Media.Core.TimedMetadataStreamDescriptor"))
 		{
-			if (avFormatCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_SUBTITLE)
+			// Get the subtitle stream
+			for (unsigned int i = 0; i < avFormatCtx->nb_streams; i++)
 			{
-				if (FAILED(CreateSubtitleStreamDescriptor(avFormatCtx->streams[i])))
+				if (avFormatCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_SUBTITLE)
 				{
-					continue;
+					if (FAILED(CreateSubtitleStreamDescriptor(avFormatCtx->streams[i])))
+					{
+						continue;
+					}
+
+					subtitleStreamIndex = i;
+
+					hr = subtitleSampleProvider->AllocateResources();
+					if (SUCCEEDED(hr))
+					{
+						m_pReader->SetSubtitleStream(subtitleStreamIndex, subtitleSampleProvider);
+					}
+
+					if (SUCCEEDED(hr))
+					{
+						hr = ConvertCodecName(avcodec_get_name(avFormatCtx->streams[i]->codecpar->codec_id), &subtitleCodecName);
+					}
+
+					break;
 				}
-
-				subtitleStreamIndex = i;
-
-				hr = subtitleSampleProvider->AllocateResources();
-				if (SUCCEEDED(hr))
-				{
-					m_pReader->SetSubtitleStream(subtitleStreamIndex, subtitleSampleProvider);
-				}
-
-				if (SUCCEEDED(hr))
-				{
-					hr = ConvertCodecName(avcodec_get_name(avFormatCtx->streams[i]->codecpar->codec_id), &subtitleCodecName);
-				}
-
-				break;
 			}
 		}
 	}

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -8,7 +8,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
   </PropertyGroup>

--- a/Samples/MediaPlayerCS/MediaPlayerCS.csproj
+++ b/Samples/MediaPlayerCS/MediaPlayerCS.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>MediaPlayerCS</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <FileAlignment>512</FileAlignment>

--- a/Tests/UnitTest.csproj
+++ b/Tests/UnitTest.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>UnitTest</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>


### PR DESCRIPTION
This change updates FFmpegInteropMSS to be [version adaptive ](https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/version-adaptive-code) and lowers all of the projects' minimum supported version.