### PR TITLE
MSFT: 31464795 - Handle dynamic audio format changes in UncompressedAudioSampleProvider

### DIFF
--- a/FFmpegInterop/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedAudioSampleProvider.cpp
@@ -162,7 +162,6 @@ HRESULT UncompressedAudioSampleProvider::InitResampler()
 
 	if (swr_init(m_pSwrCtx) < 0)
 	{
-		swr_free(&m_pSwrCtx);
 		return E_FAIL;
 	}
 

--- a/FFmpegInterop/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedAudioSampleProvider.cpp
@@ -97,7 +97,7 @@ HRESULT UncompressedAudioSampleProvider::ProcessDecodedFrame(DataWriter^ dataWri
 	// Resample uncompressed frame to AV_SAMPLE_FMT_S16 PCM format that is expected by Media Element
 	uint8_t *resampledData = nullptr;
 	unsigned int aBufferSize = av_samples_alloc(&resampledData, NULL, m_pAvFrame->channels, m_pAvFrame->nb_samples, AV_SAMPLE_FMT_S16, 0);
-	int resampledDataSize = swr_convert(m_pSwrCtx, &resampledData, aBufferSize, (const uint8_t **)m_pAvFrame->extended_data, m_pAvFrame->nb_samples);
+	int resampledDataSize = swr_convert(m_pSwrCtx, &resampledData, m_pAvFrame->nb_samples, (const uint8_t **)m_pAvFrame->extended_data, m_pAvFrame->nb_samples);
 	auto aBuffer = ref new Platform::Array<uint8_t>(resampledData, min(aBufferSize, (unsigned int)(resampledDataSize * m_pAvFrame->channels * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16))));
 	dataWriter->WriteBytes(aBuffer);
 	av_freep(&resampledData);

--- a/FFmpegInterop/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedAudioSampleProvider.cpp
@@ -30,6 +30,9 @@ UncompressedAudioSampleProvider::UncompressedAudioSampleProvider(
 	AVFormatContext* avFormatCtx,
 	AVCodecContext* avCodecCtx)
 	: UncompressedSampleProvider(reader, avFormatCtx, avCodecCtx)
+	, m_outputSampleFormat(avCodecCtx->sample_fmt)
+	, m_outputChannelLayout(m_pAvCodecCtx->channel_layout ? m_pAvCodecCtx->channel_layout : av_get_default_channel_layout(m_pAvCodecCtx->channels))
+	, m_outputSampleRate(avCodecCtx->sample_rate)
 	, m_pSwrCtx(nullptr)
 {
 }
@@ -38,36 +41,17 @@ HRESULT UncompressedAudioSampleProvider::AllocateResources()
 {
 	HRESULT hr = S_OK;
 	hr = UncompressedSampleProvider::AllocateResources();
-	if (SUCCEEDED(hr))
+	if (FAILED(hr))
 	{
-		// Set default channel layout when the value is unknown (0)
-		int64 inChannelLayout = m_pAvCodecCtx->channel_layout ? m_pAvCodecCtx->channel_layout : av_get_default_channel_layout(m_pAvCodecCtx->channels);
-		int64 outChannelLayout = av_get_default_channel_layout(m_pAvCodecCtx->channels);
-
-		// Set up resampler to convert any PCM format (e.g. AV_SAMPLE_FMT_FLTP) to AV_SAMPLE_FMT_S16 PCM format that is expected by Media Element.
-		// Additional logic can be added to avoid resampling PCM data that is already in AV_SAMPLE_FMT_S16_PCM.
-		m_pSwrCtx = swr_alloc_set_opts(
-			NULL,
-			outChannelLayout,
-			AV_SAMPLE_FMT_S16,
-			m_pAvCodecCtx->sample_rate,
-			inChannelLayout,
-			m_pAvCodecCtx->sample_fmt,
-			m_pAvCodecCtx->sample_rate,
-			0,
-			NULL);
-
-		if (!m_pSwrCtx)
-		{
-			hr = E_OUTOFMEMORY;
-		}
+		return hr;
 	}
-
-	if (SUCCEEDED(hr))
+	
+	if (m_pAvCodecCtx->sample_fmt != AV_SAMPLE_FMT_S16)
 	{
-		if (swr_init(m_pSwrCtx) < 0)
+		hr = InitResampler();
+		if (FAILED(hr))
 		{
-			hr = E_FAIL;
+			return hr;
 		}
 	}
 
@@ -94,15 +78,92 @@ HRESULT UncompressedAudioSampleProvider::WriteAVPacketToStream(DataWriter^ dataW
 
 HRESULT UncompressedAudioSampleProvider::ProcessDecodedFrame(DataWriter^ dataWriter)
 {
-	// Resample uncompressed frame to AV_SAMPLE_FMT_S16 PCM format that is expected by Media Element
-	uint8_t *resampledData = nullptr;
-	unsigned int aBufferSize = av_samples_alloc(&resampledData, NULL, m_pAvFrame->channels, m_pAvFrame->nb_samples, AV_SAMPLE_FMT_S16, 0);
-	int resampledDataSize = swr_convert(m_pSwrCtx, &resampledData, m_pAvFrame->nb_samples, (const uint8_t **)m_pAvFrame->extended_data, m_pAvFrame->nb_samples);
-	auto aBuffer = ref new Platform::Array<uint8_t>(resampledData, min(aBufferSize, (unsigned int)(resampledDataSize * m_pAvFrame->channels * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16))));
+	HRESULT hr = S_OK;
+
+	// Check if the format changed
+	bool initResampler = false;
+	if (m_pSwrCtx == nullptr)
+	{
+		initResampler =
+			m_outputSampleFormat != m_pAvCodecCtx->sample_fmt ||
+			m_outputChannelLayout != (m_pAvCodecCtx->channel_layout ? m_pAvCodecCtx->channel_layout : av_get_default_channel_layout(m_pAvCodecCtx->channels)) ||
+			m_outputSampleRate != m_pAvCodecCtx->sample_rate;
+	}
+	else
+	{
+		AVSampleFormat inputSampleFormat = AV_SAMPLE_FMT_NONE;
+		(void) av_opt_get_sample_fmt(m_pSwrCtx, "isf", 0, &inputSampleFormat);
+		int64_t inputChanneLayout = 0;
+		(void) av_opt_get_channel_layout(m_pSwrCtx, "icl", 0, &inputChanneLayout);
+		int64_t inputSampleRate = 0;
+		(void) av_opt_get_int(m_pSwrCtx, "isr", 0, &inputSampleRate);
+
+		initResampler = 
+			inputSampleFormat != m_pAvCodecCtx->sample_fmt ||
+			inputChanneLayout != (m_pAvCodecCtx->channel_layout ? m_pAvCodecCtx->channel_layout : av_get_default_channel_layout(m_pAvCodecCtx->channels)) ||
+			inputSampleRate != m_pAvCodecCtx->sample_rate;
+	}
+
+	if (initResampler)
+	{
+		hr = InitResampler();
+		if (FAILED(hr))
+		{
+			return hr;
+		}
+			
+	}
+
+	Platform::Array<uint8_t>^ aBuffer = nullptr;
+	if (m_pSwrCtx == nullptr)
+	{
+		aBuffer = ref new Platform::Array<uint8_t>(m_pAvFrame->buf[0]->data, m_pAvFrame->buf[0]->size);
+	}
+	else
+	{
+		// Resample uncompressed frame to AV_SAMPLE_FMT_S16 PCM format
+		uint8_t *resampledData = nullptr;
+		int aBufferSize = av_samples_alloc(&resampledData, NULL, av_get_channel_layout_nb_channels(m_outputChannelLayout), m_pAvFrame->nb_samples, AV_SAMPLE_FMT_S16, 0);
+		if (aBufferSize < 0)
+		{
+			return E_FAIL;
+		}
+
+		int resampledDataSize = swr_convert(m_pSwrCtx, &resampledData, m_pAvFrame->nb_samples, (const uint8_t **)m_pAvFrame->extended_data, m_pAvFrame->nb_samples);
+		aBuffer = ref new Platform::Array<uint8_t>(resampledData, min(aBufferSize, (unsigned int)(resampledDataSize * m_pAvFrame->channels * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16))));
+		av_freep(&resampledData);
+	}
+
 	dataWriter->WriteBytes(aBuffer);
-	av_freep(&resampledData);
-	av_frame_unref(m_pAvFrame);
 	av_frame_free(&m_pAvFrame);
+
+	return S_OK;
+}
+
+HRESULT UncompressedAudioSampleProvider::InitResampler()
+{
+	// Set up resampler to convert any PCM format (e.g. AV_SAMPLE_FMT_FLTP) to AV_SAMPLE_FMT_S16 PCM format that is expected by Media Element.
+	m_pSwrCtx = swr_alloc_set_opts(
+		m_pSwrCtx,
+		m_outputChannelLayout,
+		AV_SAMPLE_FMT_S16,
+		m_outputSampleRate,
+		m_pAvCodecCtx->channel_layout ? m_pAvCodecCtx->channel_layout : av_get_default_channel_layout(m_pAvCodecCtx->channels),
+		m_pAvCodecCtx->sample_fmt,
+		m_pAvCodecCtx->sample_rate,
+		0,
+		NULL);
+
+	if (!m_pSwrCtx)
+	{
+		return E_OUTOFMEMORY;
+	}
+
+	if (swr_init(m_pSwrCtx) < 0)
+	{
+		swr_free(&m_pSwrCtx);
+		return E_FAIL;
+	}
 
 	return S_OK;
 }

--- a/FFmpegInterop/UncompressedAudioSampleProvider.h
+++ b/FFmpegInterop/UncompressedAudioSampleProvider.h
@@ -42,6 +42,11 @@ namespace FFmpegInterop
 		virtual HRESULT AllocateResources() override;
 
 	private:
+		HRESULT InitResampler();
+
+		AVSampleFormat m_outputSampleFormat;
+		uint64_t m_outputChannelLayout;
+		int m_outputSampleRate;
 		SwrContext* m_pSwrCtx;
 	};
 }

--- a/FFmpegInterop/UncompressedAudioSampleProvider.h
+++ b/FFmpegInterop/UncompressedAudioSampleProvider.h
@@ -44,7 +44,9 @@ namespace FFmpegInterop
 	private:
 		HRESULT InitResampler();
 
-		AVSampleFormat m_outputSampleFormat;
+		AVSampleFormat m_inputSampleFormat;
+		uint64_t m_inputChannelLayout;
+		int m_inputSampleRate;
 		uint64_t m_outputChannelLayout;
 		int m_outputSampleRate;
 		SwrContext* m_pSwrCtx;

--- a/FFmpegInterop/pch.h
+++ b/FFmpegInterop/pch.h
@@ -23,6 +23,11 @@
 #include <mferror.h>
 #include <wrl.h>
 
+extern "C"
+{
+#include <libavutil/opt.h>
+}
+
 // Disable debug string output on non-debug build
 #if !_DEBUG
 #define DebugMessage(x)

--- a/FFmpegInterop/pch.h
+++ b/FFmpegInterop/pch.h
@@ -23,11 +23,6 @@
 #include <mferror.h>
 #include <wrl.h>
 
-extern "C"
-{
-#include <libavutil/opt.h>
-}
-
 // Disable debug string output on non-debug build
 #if !_DEBUG
 #define DebugMessage(x)


### PR DESCRIPTION
This change updates UncompressedAudioSampleProvider to handle dynamic audio format changes.

The format change is handled internally by reconfiguring the resampler so that the media type exposed to the MSS does not change.