### PR TITLE
MSFT: 31464795 - Handle dynamic audio format changes in UncompressedAudioSampleProvider

### DIFF
--- a/FFmpegInterop/SampleProvider.cpp
+++ b/FFmpegInterop/SampleProvider.cpp
@@ -61,6 +61,8 @@ namespace winrt::FFmpegInterop::implementation
 			}
 
 			MediaPropertySet properties{ audioEncProp.Properties() };
+			properties.Insert(MF_MT_AUDIO_CHANNEL_MASK, PropertyValue::CreateUInt32(
+				codecPar->channel_layout != 0 ? static_cast<uint32_t>(codecPar->channel_layout) : static_cast<uint32_t>(av_get_default_channel_layout(codecPar->channels))));
 
 			if (GUID subtype{ unbox_value<GUID>(properties.Lookup(MF_MT_SUBTYPE)) }; subtype == MFAudioFormat_PCM || subtype == MFAudioFormat_Float)
 			{

--- a/FFmpegInterop/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedAudioSampleProvider.cpp
@@ -69,6 +69,7 @@ namespace winrt::FFmpegInterop::implementation
 		UncompressedSampleProvider::Flush();
 
 		m_lastDecodeFailed = false;
+		m_formatChangeFrame.reset();
 	}
 
 	tuple<IBuffer, int64_t, int64_t, vector<pair<GUID, IInspectable>>, vector<pair<GUID, IInspectable>>> UncompressedAudioSampleProvider::GetSampleData()

--- a/FFmpegInterop/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedAudioSampleProvider.cpp
@@ -173,7 +173,7 @@ namespace winrt::FFmpegInterop::implementation
 			{
 				if (firstDecodedSample)
 				{
-					// Update the input metadata and get the list of format changes
+					// Get the list of format changes
 					if (m_inputSampleFormat != frame->format)
 					{
 						m_inputSampleFormat = static_cast<AVSampleFormat>(frame->format);

--- a/FFmpegInterop/UncompressedAudioSampleProvider.h
+++ b/FFmpegInterop/UncompressedAudioSampleProvider.h
@@ -34,12 +34,19 @@ namespace winrt::FFmpegInterop::implementation
 		std::tuple<Windows::Storage::Streams::IBuffer, int64_t, int64_t, std::vector<std::pair<GUID, Windows::Foundation::IInspectable>>, std::vector<std::pair<GUID, Windows::Foundation::IInspectable>>> GetSampleData() override;
 
 	private:
+		void InitResampler();
+
 		// Minimum duration (in ms) for uncompressed audio samples. 
 		// We'll compact shorter decoded audio samples until this threshold is reached.
 		static constexpr int64_t MIN_AUDIO_SAMPLE_DUR_MS{ 200 };
-
 		int64_t m_minAudioSampleDur{ 0 };
+
+		AVSampleFormat m_inputSampleFormat{ AV_SAMPLE_FMT_NONE };
+		uint64_t m_channelLayout{ 0 };
+		int m_sampleRate{ 0 };
+		AVFrame_ptr m_formatChangeFrame;
 		SwrContext_ptr m_swrContext;
+
 		bool m_lastDecodeFailed{ false };
 	};
 }


### PR DESCRIPTION
This change updates UncompressedAudioSampleProvider to handle dynamic audio format changes.

The format change is propagated to the MSS which triggers a MEStreamFormatChanged event in the MF pipeline.