### PR TITLE
MSFT: 39125269 - Switch FFmpeg submodule URL protocol from git to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ffmpeg"]
 	path = ffmpeg
-	url = git://github.com/FFmpeg/FFmpeg.git
+	url = https://github.com/FFmpeg/FFmpeg.git


### PR DESCRIPTION
The [Git protocol is no longer supported](https://github.blog/2021-09-01-improving-git-protocol-security-github/).

This change switches the FFmpeg submodule URL protocol from git to https.