### PR TITLE
MSFT: 43292862, 43115907 - Add script to setup FFmpeg build environment

### DIFF
--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -10,8 +10,8 @@ common_settings=" \
     --disable-dxva2 \
     --enable-shared \
     --enable-cross-compile \
-    --extra-cflags=\"-MD -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WIN32_WINNT=0x0A00\" \
-    --extra-ldflags=\"-APPCONTAINER WindowsApp.lib -PROFILE\" \
+    --extra-cflags=\"-MD -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WIN32_WINNT=0x0A00 -GUARD:CF\" \
+    --extra-ldflags=\"-APPCONTAINER WindowsApp.lib -PROFILE -GUARD:CF -DYNAMICBASE\" \
     "
 
 # Architecture specific configure settings

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -87,12 +87,14 @@
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(ProjectDir)..\ffmpeg\Build\$(PlatformTarget)\include;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
       <AdditionalDependencies>avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib;mfplat.lib;mfuuid.lib;wmcodecdspuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ProjectDir)..\ffmpeg\Build\$(PlatformTarget)\bin;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/GUARD:CF %(AdditionalOptions)</AdditionalOptions>
       <ModuleDefinitionFile>FFmpegInterop.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -87,14 +87,12 @@
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(ProjectDir)..\ffmpeg\Build\$(PlatformTarget)\include;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
       <AdditionalDependencies>avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib;mfplat.lib;mfuuid.lib;wmcodecdspuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ProjectDir)..\ffmpeg\Build\$(PlatformTarget)\bin;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalOptions>/GUARD:CF %(AdditionalOptions)</AdditionalOptions>
       <ModuleDefinitionFile>FFmpegInterop.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -109,8 +107,10 @@
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
+      <AdditionalOptions>/GUARD:CF %(AdditionalOptions)</AdditionalOptions>
       <Profile>true</Profile>
     </Link>
   </ItemDefinitionGroup>

--- a/FFmpegInterop/FFmpegInteropBuffer.cpp
+++ b/FFmpegInterop/FFmpegInteropBuffer.cpp
@@ -55,7 +55,7 @@ namespace winrt::FFmpegInterop::implementation
 		}
 	}
 
-	FFmpegInteropBuffer::FFmpegInteropBuffer(_In_reads_(bufSize) AVBlob_ptr buf, _In_ uint32_t bufSize) :
+	FFmpegInteropBuffer::FFmpegInteropBuffer(_In_ AVBlob_ptr buf, _In_ uint32_t bufSize) :
 		m_length(bufSize),
 		m_buf(static_cast<uint8_t*>(buf.get()), [AVBlob_ptr{ buf.get() }](uint8_t*) noexcept { })
 	{

--- a/FFmpegInterop/FFmpegInteropBuffer.h
+++ b/FFmpegInterop/FFmpegInteropBuffer.h
@@ -31,7 +31,7 @@ namespace winrt::FFmpegInterop::implementation
 		FFmpegInteropBuffer(_In_ AVBufferRef* bufRef);
 		FFmpegInteropBuffer(_In_ AVBufferRef_ptr bufRef) noexcept;
 		FFmpegInteropBuffer(_In_ AVPacket_ptr packet);
-		FFmpegInteropBuffer(_In_reads_(bufSize) AVBlob_ptr buf, _In_ uint32_t bufSize);
+		FFmpegInteropBuffer(_In_ AVBlob_ptr buf, _In_ uint32_t bufSize);
 		FFmpegInteropBuffer(_In_ std::vector<uint8_t>&& buf) noexcept;
 
 		// IBuffer

--- a/FFmpegInterop/FFmpegInteropMSSConfig.h
+++ b/FFmpegInterop/FFmpegInteropMSSConfig.h
@@ -30,7 +30,7 @@ namespace winrt::FFmpegInterop::implementation
         bool ForceAudioDecode();
         void ForceAudioDecode(_In_ bool forceAudioDecode);
         bool ForceVideoDecode();
-        void ForceVideoDecode(bool forceVideoDecode);
+        void ForceVideoDecode(_In_ bool forceVideoDecode);
         uint32_t AllowedDecodeErrors();
         void AllowedDecodeErrors(_In_ uint32_t allowedDecodeErrors);
         Windows::Foundation::Collections::StringMap FFmpegOptions();

--- a/SetupFFmpegBuildEnvironment.ps1
+++ b/SetupFFmpegBuildEnvironment.ps1
@@ -1,0 +1,93 @@
+###################################################
+# Copyright (C) Microsoft. All rights reserved.
+# 
+# Setup the FFmpeg build environment.
+# https://trac.ffmpeg.org/wiki/CompilationGuide/WinRT
+###################################################
+
+$install_dir = 'C:'
+$msys2_root = "$install_dir\msys64"
+$msys2_bin = "$msys2_root\usr\bin"
+
+# Get the latest MSYS2 release
+Write-Host 'Fetching releases...'
+$repo = 'msys2/msys2-installer'
+$url = "https://api.github.com/repos/$repo/releases"
+$releases = Invoke-WebRequest $url -UseBasicParsing | ConvertFrom-Json
+$release = $releases[0]
+Write-Host "Latest release: $($release.tag_name)"
+
+# Download msys2-base-x86_64-YYYYMMDD.tar.xz
+$archive = "msys2-base-x86_64-$($release.tag_name.replace('-', '')).tar.xz"
+Write-Host "Downloading $archive..."
+$archive_url = ($release.assets | where name -eq $archive).browser_download_url
+Invoke-WebRequest $archive_url -OutFile $archive -UseBasicParsing
+
+# Delete install directory if it already exists
+if (Test-Path $msys2_root)
+{
+    Write-Host "Deleting $msys2_root..."
+    Remove-Item -Recurse -Force $msys2_root
+}
+
+# Extract msys2-base-x86_64-YYYYMMDD.tar.xz
+if (Get-Command 7z -ErrorAction Ignore)
+{
+    Write-Host "Extracting $archive to $msys2_root with 7z..."
+    cmd /c "7z x $archive -so | 7z x -si -ttar -o$install_dir -bso0"
+}
+elseif (Get-Command tar -ErrorAction Ignore)
+{
+    Write-Host "Extracting $archive to $msys2_root with tar..."
+    tar -xvf $archive -C $install_dir
+}
+else
+{
+    if (-not (Get-Command Expand-7Zip -ErrorAction Ignore))
+    {
+        Write-Host 'Installing 7Zip4PowerShell...'
+        Install-Module -Name 7Zip4PowerShell -Scope CurrentUser -Force
+    }
+
+    Write-Host "Extracting $archive to $msys2_root with 7Zip4PowerShell..."
+    $uncompressed_archive = $archive.Replace('.xz', '')
+    Expand-7Zip $archive .\
+    Expand-7Zip $uncompressed_archive "$install_dir\"
+    Remove-Item $uncompressed_archive
+}
+
+Remove-Item $archive
+
+# Set MSYS2_PATH_TYPE=inherit in msys2_shell.cmd
+$msys2_shell = "$msys2_root\msys2_shell.cmd"
+Write-Host "Modifying $msys2_shell..."
+(Get-Content $msys2_shell).replace('rem set MSYS2_PATH_TYPE=inherit', 'set MSYS2_PATH_TYPE=inherit') | Set-Content $msys2_shell
+
+# Update packages
+Write-Host 'Updating packages...'
+for ($i = 0; $i -lt 2; $i++)
+{
+    Start-Process -Wait $msys2_shell -ArgumentList '-c "pacman -Syuu --noconfirm"'
+}
+
+# Install additional packages 
+$packages = @('make', 'gcc', 'diffutils', 'yasm')
+foreach ($package in $packages)
+{
+    Write-Host "Installing $package..."
+    Start-Process -Wait $msys2_shell -ArgumentList "-c `"pacman -S $package --noconfirm`""
+}
+
+# Rename link.exe to prevent conflict with MSVC
+$link = "$msys2_bin\link.exe"
+Write-Host "Renaming $link..."
+Rename-Item -Path $link -NewName "$link.0000"
+
+# Download gas-preprocessor.pl
+Write-Host "Downloading gas-preprocessor.pl to $msys2_bin\gas-preprocessor.pl..."
+$url = 'https://raw.githubusercontent.com/FFmpeg/gas-preprocessor/master/gas-preprocessor.pl'
+Invoke-WebRequest $url -OutFile "$msys2_bin\gas-preprocessor.pl" -UseBasicParsing
+
+# Set MSYS2_BIN environment variable
+Write-Host 'Setting MSYS2_BIN environment variable...'
+[System.Environment]::SetEnvironmentVariable('MSYS2_BIN', "$msys2_bin\bash.exe", "User")

--- a/SetupFFmpegBuildEnvironment.ps1
+++ b/SetupFFmpegBuildEnvironment.ps1
@@ -43,17 +43,8 @@ elseif (Get-Command tar -ErrorAction Ignore)
 }
 else
 {
-    if (-not (Get-Command Expand-7Zip -ErrorAction Ignore))
-    {
-        Write-Host 'Installing 7Zip4PowerShell...'
-        Install-Module -Name 7Zip4PowerShell -Scope CurrentUser -Force
-    }
-
-    Write-Host "Extracting $archive to $msys2_root with 7Zip4PowerShell..."
-    $uncompressed_archive = $archive.Replace('.xz', '')
-    Expand-7Zip $archive .\
-    Expand-7Zip $uncompressed_archive "$install_dir\"
-    Remove-Item $uncompressed_archive
+    Write-Error 'Please install 7z.exe or tar.exe and add to $env:PATH.'
+    exit 1
 }
 
 Remove-Item $archive


### PR DESCRIPTION
- Add SetupFFmpegBuildEnvironment.ps1, a script to set up the FFmpeg build environment
- Address [BA2008.EnableControlFlowGuard](https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2008EnableControlFlowGuard) BinSkim errors by building FFmpeg and FFmpegInterop binaries with CFG ([/guard:cf (compiler)](https://learn.microsoft.com/en-us/cpp/build/reference/guard-enable-control-flow-guard?view=msvc-170), [/GUARD:CF (linker)](https://learn.microsoft.com/en-us/cpp/build/reference/guard-enable-guard-checks?view=msvc-170)) enabled
- Address PREfast warnings by fixing SAL annotations