### PR TITLE
MSFT: 39125187 - Update FFmpeg to 6.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ffmpeg"]
 	path = ffmpeg
 	url = https://github.com/FFmpeg/FFmpeg.git
-	branch = release/4.1
+	branch = release/6.0

--- a/FFmpegInterop/ACMSampleProvider.cpp
+++ b/FFmpegInterop/ACMSampleProvider.cpp
@@ -46,11 +46,11 @@ namespace winrt::FFmpegInterop::implementation
 		waveFormatExtensible->SubFormat = MFAudioFormat_Base;
 		waveFormatExtensible->SubFormat.Data1 = codecPar->codec_tag;
 		waveFormatExtensible->Samples.wValidBitsPerSample = setValidBitsPerSample ? codecPar->bits_per_coded_sample : 0;
-		waveFormatExtensible->dwChannelMask = static_cast<uint32_t>(codecPar->channel_layout);
+		waveFormatExtensible->dwChannelMask = codecPar->ch_layout.order == AV_CHANNEL_ORDER_NATIVE ? static_cast<uint32_t>(codecPar->ch_layout.u.mask) : 0;
 
 		WAVEFORMATEX& waveFormatEx{ waveFormatExtensible->Format };
 		waveFormatEx.wFormatTag = WAVE_FORMAT_EXTENSIBLE;
-		waveFormatEx.nChannels = codecPar->channels;
+		waveFormatEx.nChannels = codecPar->ch_layout.nb_channels;
 		waveFormatEx.nSamplesPerSec = codecPar->sample_rate;
 		waveFormatEx.nAvgBytesPerSec = static_cast<uint32_t>(codecPar->bit_rate / BITS_PER_BYTE);
 		waveFormatEx.nBlockAlign = codecPar->block_align;

--- a/FFmpegInterop/FFmpegInteropBuffer.h
+++ b/FFmpegInterop/FFmpegInteropBuffer.h
@@ -29,14 +29,14 @@ namespace winrt::FFmpegInterop::implementation
 	{
 	public:
 		FFmpegInteropBuffer(_In_ AVBufferRef* bufRef);
-		FFmpegInteropBuffer(_In_ AVBufferRef_ptr bufRef) noexcept;
+		FFmpegInteropBuffer(_In_ AVBufferRef_ptr bufRef);
 		FFmpegInteropBuffer(_In_ AVPacket_ptr packet);
 		FFmpegInteropBuffer(_In_ AVBlob_ptr buf, _In_ uint32_t bufSize);
 		FFmpegInteropBuffer(_In_ std::vector<uint8_t>&& buf) noexcept;
 
 		// IBuffer
-		uint32_t Capacity() const noexcept;
-		uint32_t Length() const noexcept;
+		STDMETHODIMP_(uint32_t) Capacity() const noexcept;
+		STDMETHODIMP_(uint32_t) Length() const noexcept;
 		void Length(_In_ uint32_t length);
 
 		// IBufferByteAccess

--- a/FFmpegInterop/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/FFmpegInteropMSS.cpp
@@ -237,6 +237,7 @@ namespace winrt::FFmpegInterop::implementation
 						{
 							m_mss.AddStreamDescriptor(move(audioStreamDescriptor));
 						}
+						pendingAudioStreamDescriptors.clear();
 					}
 				}
 				else
@@ -273,6 +274,7 @@ namespace winrt::FFmpegInterop::implementation
 						{
 							m_mss.AddStreamDescriptor(move(videoStreamDescriptor));
 						}
+						pendingVideoStreamDescriptors.clear();
 					}
 				}
 				else

--- a/FFmpegInterop/FLACSampleProvider.cpp
+++ b/FFmpegInterop/FLACSampleProvider.cpp
@@ -50,7 +50,7 @@ namespace winrt::FFmpegInterop::implementation
 		bitstreamReader.SkipN(24); // Min frame size
 		bitstreamReader.SkipN(24); // Max frame size
 		m_stream->codecpar->sample_rate = static_cast<int>(bitstreamReader.ReadN(20));
-		m_stream->codecpar->channels = static_cast<int>(bitstreamReader.ReadN(3)) + 1;
+		m_stream->codecpar->ch_layout.nb_channels = static_cast<int>(bitstreamReader.ReadN(3)) + 1;
 		m_stream->codecpar->bits_per_raw_sample = static_cast<int>(bitstreamReader.ReadN(5)) + 1;
 		// Remaining fields left unparsed as they are unneeded at this time
 	}

--- a/FFmpegInterop/SampleProvider.cpp
+++ b/FFmpegInterop/SampleProvider.cpp
@@ -49,7 +49,7 @@ namespace winrt::FFmpegInterop::implementation
 		{
 			IAudioEncodingProperties audioEncProp{ encProp.as<IAudioEncodingProperties>() };
 			audioEncProp.SampleRate(codecPar->sample_rate);
-			audioEncProp.ChannelCount(codecPar->channels);
+			audioEncProp.ChannelCount(codecPar->ch_layout.nb_channels);
 			audioEncProp.Bitrate(static_cast<uint32_t>(codecPar->bit_rate));
 			audioEncProp.BitsPerSample(static_cast<uint32_t>(max(codecPar->bits_per_coded_sample, codecPar->bits_per_raw_sample)));
 
@@ -61,8 +61,11 @@ namespace winrt::FFmpegInterop::implementation
 			}
 
 			MediaPropertySet properties{ audioEncProp.Properties() };
-			properties.Insert(MF_MT_AUDIO_CHANNEL_MASK, PropertyValue::CreateUInt32(
-				codecPar->channel_layout != 0 ? static_cast<uint32_t>(codecPar->channel_layout) : static_cast<uint32_t>(av_get_default_channel_layout(codecPar->channels))));
+
+			if (codecPar->ch_layout.order == AV_CHANNEL_ORDER_NATIVE)
+			{
+				properties.Insert(MF_MT_AUDIO_CHANNEL_MASK, PropertyValue::CreateUInt32(static_cast<uint32_t>(codecPar->ch_layout.u.mask)));
+			}
 
 			if (GUID subtype{ unbox_value<GUID>(properties.Lookup(MF_MT_SUBTYPE)) }; subtype == MFAudioFormat_PCM || subtype == MFAudioFormat_Float)
 			{

--- a/FFmpegInterop/SampleProvider.cpp
+++ b/FFmpegInterop/SampleProvider.cpp
@@ -66,6 +66,11 @@ namespace winrt::FFmpegInterop::implementation
 			{
 				properties.Insert(MF_MT_AUDIO_CHANNEL_MASK, PropertyValue::CreateUInt32(static_cast<uint32_t>(codecPar->ch_layout.u.mask)));
 			}
+			else if (codecPar->ch_layout.order != AV_CHANNEL_ORDER_UNSPEC)
+			{
+				// We don't currently support other channel orders
+				THROW_HR(MF_E_INVALIDMEDIATYPE);
+			}
 
 			if (GUID subtype{ unbox_value<GUID>(properties.Lookup(MF_MT_SUBTYPE)) }; subtype == MFAudioFormat_PCM || subtype == MFAudioFormat_Float)
 			{

--- a/FFmpegInterop/StreamFactory.cpp
+++ b/FFmpegInterop/StreamFactory.cpp
@@ -111,11 +111,11 @@ namespace winrt::FFmpegInterop::implementation
 		case AV_CODEC_ID_AAC:
 			if (stream->codecpar->extradata_size == 0)
 			{
-				audioEncProp = AudioEncodingProperties::CreateAacAdts(stream->codecpar->sample_rate, stream->codecpar->channels, static_cast<uint32_t>(stream->codecpar->bit_rate));
+				audioEncProp = AudioEncodingProperties::CreateAacAdts(stream->codecpar->sample_rate, stream->codecpar->ch_layout.nb_channels, static_cast<uint32_t>(stream->codecpar->bit_rate));
 			}
 			else
 			{
-				audioEncProp = AudioEncodingProperties::CreateAac(stream->codecpar->sample_rate, stream->codecpar->channels, static_cast<uint32_t>(stream->codecpar->bit_rate));
+				audioEncProp = AudioEncodingProperties::CreateAac(stream->codecpar->sample_rate, stream->codecpar->ch_layout.nb_channels, static_cast<uint32_t>(stream->codecpar->bit_rate));
 			}
 
 			audioSampleProvider = make_unique<SampleProvider>(formatContext, stream, reader);
@@ -154,7 +154,7 @@ namespace winrt::FFmpegInterop::implementation
 			break;
 
 		case AV_CODEC_ID_MP3:
-			audioEncProp = AudioEncodingProperties::CreateMp3(stream->codecpar->sample_rate, stream->codecpar->channels, static_cast<uint32_t>(stream->codecpar->bit_rate));
+			audioEncProp = AudioEncodingProperties::CreateMp3(stream->codecpar->sample_rate, stream->codecpar->ch_layout.nb_channels, static_cast<uint32_t>(stream->codecpar->bit_rate));
 			audioSampleProvider = make_unique<SampleProvider>(formatContext, stream, reader);
 			break;
 
@@ -198,7 +198,7 @@ namespace winrt::FFmpegInterop::implementation
 
 		default:
 			constexpr uint32_t bitsPerSample{ 16 };
-			audioEncProp = AudioEncodingProperties::CreatePcm(stream->codecpar->sample_rate, stream->codecpar->channels, bitsPerSample);
+			audioEncProp = AudioEncodingProperties::CreatePcm(stream->codecpar->sample_rate, stream->codecpar->ch_layout.nb_channels, bitsPerSample);
 			audioSampleProvider = make_unique<UncompressedAudioSampleProvider>(formatContext, stream, reader, config != nullptr ? config.AllowedDecodeErrors() : FFmpegInteropMSSConfig::kAllowedDecodeErrorsDefault);
 			break;
 		}

--- a/FFmpegInterop/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedAudioSampleProvider.cpp
@@ -67,6 +67,11 @@ namespace winrt::FFmpegInterop::implementation
 		{
 			properties.Insert(MF_MT_AUDIO_CHANNEL_MASK, PropertyValue::CreateUInt32(static_cast<uint32_t>(m_channelLayout.u.mask)));
 		}
+		else if (m_channelLayout.order != AV_CHANNEL_ORDER_UNSPEC)
+		{
+			// We don't currently support other channel orders
+			THROW_HR(MF_E_INVALIDMEDIATYPE);
+		}
 	}
 
 	void UncompressedAudioSampleProvider::Flush() noexcept
@@ -189,6 +194,11 @@ namespace winrt::FFmpegInterop::implementation
 						if (frame->ch_layout.order == AV_CHANNEL_ORDER_NATIVE)
 						{
 							formatChanges.emplace_back(MF_MT_AUDIO_CHANNEL_MASK, PropertyValue::CreateUInt32(static_cast<uint32_t>(frame->ch_layout.u.mask)));
+						}
+						else if (frame->ch_layout.order != AV_CHANNEL_ORDER_UNSPEC)
+						{
+							// We don't currently support other channel orders
+							THROW_HR(MF_E_INVALIDMEDIATYPE);
 						}
 
 						if (m_channelLayout.nb_channels != frame->ch_layout.nb_channels)

--- a/FFmpegInterop/UncompressedAudioSampleProvider.h
+++ b/FFmpegInterop/UncompressedAudioSampleProvider.h
@@ -42,7 +42,7 @@ namespace winrt::FFmpegInterop::implementation
 		int64_t m_minAudioSampleDur{ 0 };
 
 		AVSampleFormat m_inputSampleFormat{ AV_SAMPLE_FMT_NONE };
-		uint64_t m_channelLayout{ 0 };
+		AVChannelLayoutWrapper m_channelLayout;
 		int m_sampleRate{ 0 };
 		AVFrame_ptr m_formatChangeFrame;
 		SwrContext_ptr m_swrContext;

--- a/FFmpegInterop/UncompressedSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedSampleProvider.cpp
@@ -29,7 +29,7 @@ namespace winrt::FFmpegInterop::implementation
 		m_allowedDecodeErrors(allowedDecodeErrors)
 	{
 		// Create a new decoding context
-		AVCodec* codec{ avcodec_find_decoder(stream->codecpar->codec_id) };
+		const AVCodec* codec{ avcodec_find_decoder(stream->codecpar->codec_id) };
 		THROW_HR_IF_NULL(MF_E_INVALIDMEDIATYPE, codec);
 
 		m_codecContext.reset(avcodec_alloc_context3(codec));

--- a/FFmpegInterop/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.cpp
@@ -154,7 +154,7 @@ namespace winrt::FFmpegInterop::implementation
 		// Get the sample properties
 		vector<pair<GUID, Windows::Foundation::IInspectable>> properties{ GetSampleProperties(frame.get()) };
 
-		return { move(sampleBuf), frame->best_effort_timestamp, frame->pkt_duration, move(properties), move(formatChanges) };
+		return { move(sampleBuf), frame->best_effort_timestamp, frame->duration, move(properties), move(formatChanges) };
 	}
 
 	vector<pair<GUID, Windows::Foundation::IInspectable>> UncompressedVideoSampleProvider::CheckForFormatChanges(_In_ const AVFrame* frame)

--- a/FFmpegInterop/Utility.h
+++ b/FFmpegInterop/Utility.h
@@ -187,7 +187,7 @@ namespace winrt::FFmpegInterop::implementation
 			THROW_HR_IF_FFMPEG_FAILED(av_channel_layout_copy(this, &other));
 		}
 
-		AVChannelLayoutWrapper(AVChannelLayoutWrapper&& other) :
+		AVChannelLayoutWrapper(AVChannelLayoutWrapper&& other) noexcept :
 			AVChannelLayoutWrapper()
 		{
 			*this = std::move(other);
@@ -219,7 +219,7 @@ namespace winrt::FFmpegInterop::implementation
 			return *this;
 		}
 
-		AVChannelLayoutWrapper& operator=(AVChannelLayoutWrapper&& other)
+		AVChannelLayoutWrapper& operator=(AVChannelLayoutWrapper&& other) noexcept
 		{
 			if (this != &other)
 			{

--- a/FFmpegInterop/Utility.h
+++ b/FFmpegInterop/Utility.h
@@ -171,6 +171,64 @@ namespace winrt::FFmpegInterop::implementation
 	};
 	typedef std::unique_ptr<AVCodecParameters, AVCodecParametersDeleter> AVCodecParameters_ptr;
 
+	struct AVChannelLayoutWrapper :
+		public AVChannelLayout
+	{
+		AVChannelLayoutWrapper()
+		{
+			order = AV_CHANNEL_ORDER_UNSPEC;
+			nb_channels = 0;
+			u.mask = 0;
+			opaque = nullptr;
+		}
+
+		AVChannelLayoutWrapper(const AVChannelLayout& other)
+		{
+			THROW_HR_IF_FFMPEG_FAILED(av_channel_layout_copy(this, &other));
+		}
+
+		AVChannelLayoutWrapper(AVChannelLayoutWrapper&& other) :
+			AVChannelLayoutWrapper()
+		{
+			*this = std::move(other);
+		}
+
+		AVChannelLayoutWrapper(int channels)
+		{
+			av_channel_layout_default(this, channels);
+		}
+
+		AVChannelLayoutWrapper(uint64_t mask)
+		{
+			THROW_HR_IF_FFMPEG_FAILED(av_channel_layout_from_mask(this, mask));
+		}
+
+		AVChannelLayoutWrapper(const AVChannelLayoutWrapper&) = delete;
+
+		~AVChannelLayoutWrapper()
+		{
+			av_channel_layout_uninit(this);
+		}
+
+		AVChannelLayoutWrapper& operator=(const AVChannelLayout& other)
+		{
+			if (this != &other)
+			{
+				THROW_HR_IF_FFMPEG_FAILED(av_channel_layout_copy(this, &other));
+			}
+			return *this;
+		}
+
+		AVChannelLayoutWrapper& operator=(AVChannelLayoutWrapper&& other)
+		{
+			if (this != &other)
+			{
+				std::swap(*this, other);
+			}
+			return *this;
+		}
+	};
+
 	struct AVPacketDeleter
 	{
 		void operator()(_In_opt_ AVPacket* packet)

--- a/FFmpegInterop/Utility.h
+++ b/FFmpegInterop/Utility.h
@@ -71,9 +71,9 @@ namespace winrt::FFmpegInterop::implementation
 	}
 
 	// Helper function to map AVERROR to HRESULT
-	inline HRESULT averror_to_hresult(_In_range_(< , 0) int result)
+	inline constexpr HRESULT averror_to_hresult(_In_range_(< , 0) int status) noexcept
 	{
-		switch (result)
+		switch (status)
 		{
 		case AVERROR(EINVAL):
 			return E_INVALIDARG;
@@ -89,7 +89,22 @@ namespace winrt::FFmpegInterop::implementation
 	}
 
 	// Macro to check the result of FFmpeg calls
-	#define THROW_HR_IF_FFMPEG_FAILED(result) if ((result) < 0) { THROW_HR(averror_to_hresult(result)); }
+	template <typename T>
+	_Post_satisfies_(return == status)
+	inline constexpr int verify_averror(T status)
+	{
+		static_assert(std::is_same<T, int>::value, "Wrong Type: int expected");
+		return status;
+	}
+
+	#define THROW_HR_IF_FFMPEG_FAILED(status) \
+	do { \
+		const int __status = verify_averror(status); \
+		if (__status < 0) \
+		{ \
+			THROW_HR_MSG(averror_to_hresult(__status), #status); \
+		} \
+	} while (false) \
 
 	// Helper function to create a PropertyValue from an MF attribute
 	extern winrt::Windows::Foundation::IInspectable CreatePropValueFromMFAttribute(_In_ const PROPVARIANT& propVar);
@@ -174,7 +189,7 @@ namespace winrt::FFmpegInterop::implementation
 	struct AVChannelLayoutWrapper :
 		public AVChannelLayout
 	{
-		AVChannelLayoutWrapper()
+		AVChannelLayoutWrapper() noexcept
 		{
 			order = AV_CHANNEL_ORDER_UNSPEC;
 			nb_channels = 0;
@@ -182,7 +197,14 @@ namespace winrt::FFmpegInterop::implementation
 			opaque = nullptr;
 		}
 
-		AVChannelLayoutWrapper(const AVChannelLayout& other)
+		AVChannelLayoutWrapper(const AVChannelLayout& other) :
+			AVChannelLayoutWrapper()
+		{
+			THROW_HR_IF_FFMPEG_FAILED(av_channel_layout_copy(this, &other));
+		}
+
+		AVChannelLayoutWrapper(const AVChannelLayoutWrapper& other) :
+			AVChannelLayoutWrapper()
 		{
 			THROW_HR_IF_FFMPEG_FAILED(av_channel_layout_copy(this, &other));
 		}
@@ -193,19 +215,19 @@ namespace winrt::FFmpegInterop::implementation
 			*this = std::move(other);
 		}
 
-		AVChannelLayoutWrapper(int channels)
+		AVChannelLayoutWrapper(int channels) noexcept :
+			AVChannelLayoutWrapper()
 		{
 			av_channel_layout_default(this, channels);
 		}
 
-		AVChannelLayoutWrapper(uint64_t mask)
+		AVChannelLayoutWrapper(uint64_t mask) :
+			AVChannelLayoutWrapper()
 		{
 			THROW_HR_IF_FFMPEG_FAILED(av_channel_layout_from_mask(this, mask));
 		}
 
-		AVChannelLayoutWrapper(const AVChannelLayoutWrapper&) = delete;
-
-		~AVChannelLayoutWrapper()
+		~AVChannelLayoutWrapper() noexcept
 		{
 			av_channel_layout_uninit(this);
 		}

--- a/FFmpegInterop/pch.h
+++ b/FFmpegInterop/pch.h
@@ -76,6 +76,7 @@ typedef struct _MT_CUSTOM_VIDEO_PRIMARIES {
 // FFmpeg
 extern "C"
 {
+#include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libavutil/log.h>
 #include <libavutil/imgutils.h>

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -156,25 +156,25 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avcodec-58_ms.dll">
+    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avcodec-60_ms.dll">
       <DeploymentContent>true</DeploymentContent>
     </None>
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avdevice-58_ms.dll">
+    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avdevice-60_ms.dll">
       <DeploymentContent>true</DeploymentContent>
     </None>
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avfilter-7_ms.dll">
+    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avfilter-9_ms.dll">
       <DeploymentContent>true</DeploymentContent>
     </None>
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avformat-58_ms.dll">
+    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avformat-60_ms.dll">
       <DeploymentContent>true</DeploymentContent>
     </None>
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avutil-56_ms.dll">
+    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avutil-58_ms.dll">
       <DeploymentContent>true</DeploymentContent>
     </None>
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\swresample-3_ms.dll">
+    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\swresample-4_ms.dll">
       <DeploymentContent>true</DeploymentContent>
     </None>
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\swscale-5_ms.dll">
+    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\swscale-7_ms.dll">
       <DeploymentContent>true</DeploymentContent>
     </None>
     <None Include="packages.config" />


### PR DESCRIPTION
## Why is this change being made?
We're updating to the latest version of FFmpeg.

## What changed?
This change updates FFmpeg to [6.0](https://github.com/FFmpeg/FFmpeg/releases/tag/n6.0).

## How was the change tested?
I validated the following scenarios:
- Playback in MediaPlayerCPP
  - Ogg
  - MKV
- Playback in Media Player with WME
  - Ogg
  - MKV with Vorbis/Theora 
- Ogg properties in File Explorer with WME