### PR TITLE
MSFT: 46989616 - Use WIL's TraceLogging helpers for tracing

### DIFF
--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -87,6 +87,7 @@
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(ProjectDir)..\ffmpeg\Build\$(PlatformTarget)\include;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -182,15 +182,15 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/FFmpegInterop/FFmpegInteropLogging.cpp
+++ b/FFmpegInterop/FFmpegInteropLogging.cpp
@@ -30,7 +30,8 @@ namespace winrt::FFmpegInterop::implementation
 {
 	event<EventHandler<FFmpegInterop::LogEventArgs>> FFmpegInteropLogging::m_logEvent;
 
-	void FFmpegInteropLogging::Log(_In_ void* avcl, _In_ int level, _In_ const char* fmt, _In_ va_list vl)
+	void FFmpegInteropLogging::Log(_In_ void* avcl, _In_ int level, _In_ const char* fmt, _In_ va_list vl) noexcept
+	try
 	{
 		// Get the required buffer size
 		int printPrefix{ 1 };
@@ -53,8 +54,9 @@ namespace winrt::FFmpegInterop::implementation
 
 		FFMPEG_INTEROP_TRACE("%S", line.get());
 	}
+	CATCH_LOG_RETURN()
 
-	event_token FFmpegInteropLogging::Log(_In_ const EventHandler<FFmpegInterop::LogEventArgs>& handler)
+	event_token FFmpegInteropLogging::Log(_In_ const EventHandler<FFmpegInterop::LogEventArgs>& handler) noexcept
 	{
 		return m_logEvent.add(handler);
 	}

--- a/FFmpegInterop/FFmpegInteropLogging.cpp
+++ b/FFmpegInterop/FFmpegInteropLogging.cpp
@@ -22,6 +22,7 @@
 #include "FFmpegInteropLogging.g.cpp"
 #include "LogEventArgs.h"
 
+using namespace std;
 using namespace winrt;
 using namespace winrt::Windows::Foundation;
 
@@ -31,23 +32,26 @@ namespace winrt::FFmpegInterop::implementation
 
 	void FFmpegInteropLogging::Log(_In_ void* avcl, _In_ int level, _In_ const char* fmt, _In_ va_list vl)
 	{
-		constexpr int LINE_SIZE{ 1024 };
+		// Get the required buffer size
+		int printPrefix{ 1 };
+		int lineSize = av_log_format_line2(avcl, level, fmt, vl, nullptr, 0, &printPrefix);
+		THROW_HR_IF_FFMPEG_FAILED(lineSize);
 
 		// Format the log line
-		char lineA[LINE_SIZE];
-		int printPrefix{ 1 };
-		av_log_format_line(avcl, level, fmt, vl, lineA, LINE_SIZE, &printPrefix);
+		auto line{ make_unique_for_overwrite<char[]>(lineSize + 1) };
+		int charWritten = av_log_format_line2(avcl, level, fmt, vl, line.get(), lineSize + 1, &printPrefix);
+		THROW_HR_IF_FFMPEG_FAILED(charWritten);
+		WINRT_ASSERT(lineSize == charWritten);
 
-		// Convert from UTF8 -> UTF16
-		wchar_t lineW[LINE_SIZE];
-		if (MultiByteToWideChar(CP_UTF8, MB_PRECOMPOSED, lineA, -1, lineW, LINE_SIZE) > 0)
+		m_logEvent(nullptr, make<LogEventArgs>(static_cast<FFmpegInterop::LogLevel>(level), to_hstring(line.get())));
+
+		// Trim trailing whitespace
+		for (int i{ lineSize - 1 }; i >= 0 && isspace(line[i]); i--)
 		{
-			TraceLoggingProviderWrite(FFmpegInteropProvider, "FFmpegTrace", TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
-				TraceLoggingValue(lineW, "Message"));
-
-			// Raise a log event to any registered handlers
-			m_logEvent(nullptr, make<LogEventArgs>(static_cast<FFmpegInterop::LogLevel>(level), hstring{ lineW }));
+			line[i] = '\0';
 		}
+
+		FFMPEG_INTEROP_TRACE("%S", line.get());
 	}
 
 	event_token FFmpegInteropLogging::Log(_In_ const EventHandler<FFmpegInterop::LogEventArgs>& handler)

--- a/FFmpegInterop/FFmpegInteropLogging.cpp
+++ b/FFmpegInterop/FFmpegInteropLogging.cpp
@@ -41,7 +41,7 @@ namespace winrt::FFmpegInterop::implementation
 		auto line{ make_unique_for_overwrite<char[]>(lineSize + 1) };
 		int charWritten = av_log_format_line2(avcl, level, fmt, vl, line.get(), lineSize + 1, &printPrefix);
 		THROW_HR_IF_FFMPEG_FAILED(charWritten);
-		WINRT_ASSERT(lineSize == charWritten);
+		THROW_HR_IF(E_UNEXPECTED, lineSize != charWritten);
 
 		m_logEvent(nullptr, make<LogEventArgs>(static_cast<FFmpegInterop::LogLevel>(level), to_hstring(line.get())));
 

--- a/FFmpegInterop/FFmpegInteropLogging.cpp
+++ b/FFmpegInterop/FFmpegInteropLogging.cpp
@@ -35,12 +35,12 @@ namespace winrt::FFmpegInterop::implementation
 	{
 		// Get the required buffer size
 		int printPrefix{ 1 };
-		int lineSize = av_log_format_line2(avcl, level, fmt, vl, nullptr, 0, &printPrefix);
+		int lineSize{ av_log_format_line2(avcl, level, fmt, vl, nullptr, 0, &printPrefix) };
 		THROW_HR_IF_FFMPEG_FAILED(lineSize);
 
 		// Format the log line
 		auto line{ make_unique_for_overwrite<char[]>(lineSize + 1) };
-		int charWritten = av_log_format_line2(avcl, level, fmt, vl, line.get(), lineSize + 1, &printPrefix);
+		int charWritten{ av_log_format_line2(avcl, level, fmt, vl, line.get(), lineSize + 1, &printPrefix) };
 		THROW_HR_IF_FFMPEG_FAILED(charWritten);
 		THROW_HR_IF(E_UNEXPECTED, lineSize != charWritten);
 

--- a/FFmpegInterop/FFmpegInteropLogging.cpp
+++ b/FFmpegInterop/FFmpegInteropLogging.cpp
@@ -42,7 +42,7 @@ namespace winrt::FFmpegInterop::implementation
 		wchar_t lineW[LINE_SIZE];
 		if (MultiByteToWideChar(CP_UTF8, MB_PRECOMPOSED, lineA, -1, lineW, LINE_SIZE) > 0)
 		{
-			TraceLoggingWrite(g_FFmpegInteropProvider, "FFmpegTrace", TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
+			TraceLoggingProviderWrite(FFmpegInteropProvider, "FFmpegTrace", TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
 				TraceLoggingValue(lineW, "Message"));
 
 			// Raise a log event to any registered handlers

--- a/FFmpegInterop/FFmpegInteropLogging.h
+++ b/FFmpegInterop/FFmpegInteropLogging.h
@@ -25,9 +25,9 @@ namespace winrt::FFmpegInterop::implementation
 	class FFmpegInteropLogging
 	{
 	public:
-		static void Log(_In_ void* avcl, _In_ int level, _In_ const char* fmt, _In_ va_list vl);
+		static void Log(_In_ void* avcl, _In_ int level, _In_ const char* fmt, _In_ va_list vl) noexcept;
 
-		static event_token Log(_In_ const Windows::Foundation::EventHandler<FFmpegInterop::LogEventArgs>& handler);
+		static event_token Log(_In_ const Windows::Foundation::EventHandler<FFmpegInterop::LogEventArgs>& handler) noexcept;
 		static void Log(_In_ const event_token& token) noexcept;
 
 	private:

--- a/FFmpegInterop/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/FFmpegInteropMSS.cpp
@@ -74,7 +74,7 @@ namespace winrt::FFmpegInterop::implementation
 {
 	void FFmpegInteropMSS::CreateFromStream(_In_ const IRandomAccessStream& fileStream, _In_ const MediaStreamSource& mss, _In_opt_ const FFmpegInterop::FFmpegInteropMSSConfig& config)
 	{
-		auto logger{ CreateFromStreamActivity::Start() };
+		auto logger{ FFmpegInteropProvider::CreateFromStream::Start() };
 
 		(void) make<FFmpegInteropMSS>(fileStream, mss, config);
 
@@ -83,7 +83,7 @@ namespace winrt::FFmpegInterop::implementation
 
 	void FFmpegInteropMSS::CreateFromUri(_In_ const hstring& uri, _In_ const MediaStreamSource& mss, _In_opt_ const FFmpegInterop::FFmpegInteropMSSConfig& config)
 	{
-		auto logger{ CreateFromUriActivity::Start() };
+		auto logger{ FFmpegInteropProvider::CreateFromUri::Start() };
 
 		(void) make<FFmpegInteropMSS>(uri, mss, config);
 
@@ -290,7 +290,7 @@ namespace winrt::FFmpegInterop::implementation
 				// Note: MSS didn't expose subtitle streams in media engine scenarios until 19041.
 				if (!ApiInformation::IsTypePresent(L"Windows.Media.Core.TimedMetadataStreamDescriptor"))
 				{
-					TraceLoggingWrite(g_FFmpegInteropProvider, "NoSubtitleSupport", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+					TraceLoggingProviderWrite(FFmpegInteropProvider, "NoSubtitleSupport", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 						TraceLoggingValue(stream->index, "StreamId"),
 						TraceLoggingInt32(stream->codecpar->codec_id, "AVCodecID"));
 					continue;
@@ -303,7 +303,7 @@ namespace winrt::FFmpegInterop::implementation
 				catch (...)
 				{
 					// Unsupported subtitle stream. Just ignore.
-					TraceLoggingWrite(g_FFmpegInteropProvider, "UnsupportedSubtitleStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+					TraceLoggingProviderWrite(FFmpegInteropProvider, "UnsupportedSubtitleStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 						TraceLoggingValue(stream->index, "StreamId"),
 						TraceLoggingInt32(stream->codecpar->codec_id, "AVCodecID"));
 					continue;
@@ -316,7 +316,7 @@ namespace winrt::FFmpegInterop::implementation
 
 			default:
 				// Ignore this stream
-				TraceLoggingWrite(g_FFmpegInteropProvider, "UnsupportedStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+				TraceLoggingProviderWrite(FFmpegInteropProvider, "UnsupportedStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 					TraceLoggingValue(stream->index, "StreamId"),
 					TraceLoggingInt32(stream->codecpar->codec_type, "AVMediaType"),
 					TraceLoggingInt32(stream->codecpar->codec_id, "AVCodecID"));
@@ -358,7 +358,7 @@ namespace winrt::FFmpegInterop::implementation
 
 	void FFmpegInteropMSS::OnStarting(_In_ const MediaStreamSource&, _In_ const MediaStreamSourceStartingEventArgs& args)
 	{
-		auto logger{ OnStartingActivity::Start() };
+		auto logger{ FFmpegInteropProvider::OnStarting::Start() };
 
 		const MediaStreamSourceStartingRequest request{ args.Request() };
 		const IReference<TimeSpan> startPosition{ request.StartPosition() };
@@ -369,7 +369,7 @@ namespace winrt::FFmpegInterop::implementation
 			lock_guard<mutex> lock{ m_lock };
 
 			const TimeSpan hnsSeekTime{ startPosition.Value() };
-			TraceLoggingWrite(g_FFmpegInteropProvider, "Seek", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+			TraceLoggingProviderWrite(FFmpegInteropProvider, "Seek", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 				TraceLoggingValue(hnsSeekTime.count(), "SeekTimeHNS"));
 			
 			try
@@ -403,14 +403,14 @@ namespace winrt::FFmpegInterop::implementation
 		}
 		else
 		{
-			TraceLoggingWrite(g_FFmpegInteropProvider, "Resume", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"));
+			TraceLoggingProviderWrite(FFmpegInteropProvider, "Resume", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"));
 			logger.Stop();
 		}
 	}
 
 	void FFmpegInteropMSS::OnSampleRequested(_In_ const MediaStreamSource&, _In_ const MediaStreamSourceSampleRequestedEventArgs& args)
 	{
-		auto logger{ OnSampleRequestedActivity::Start() };
+		auto logger{ FFmpegInteropProvider::OnSampleRequested::Start() };
 
 		const MediaStreamSourceSampleRequest request{ args.Request() };
 
@@ -446,7 +446,7 @@ namespace winrt::FFmpegInterop::implementation
 
 	void FFmpegInteropMSS::OnSwitchStreamsRequested(_In_ const MediaStreamSource&, _In_ const MediaStreamSourceSwitchStreamsRequestedEventArgs& args)
 	{
-		auto logger{ OnSwitchStreamsRequestedActivity::Start() };
+		auto logger{ FFmpegInteropProvider::OnSwitchStreamsRequested::Start() };
 
 		const MediaStreamSourceSwitchStreamsRequest request{ args.Request() };
 		const IMediaStreamDescriptor oldStreamDescriptor{ request.OldStreamDescriptor() };
@@ -482,7 +482,7 @@ namespace winrt::FFmpegInterop::implementation
 
 	void FFmpegInteropMSS::OnClosed(_In_ const MediaStreamSource&, _In_ const MediaStreamSourceClosedEventArgs& args)
 	{
-		auto logger{ OnClosedActivity::Start() };
+		auto logger{ FFmpegInteropProvider::OnClosed::Start() };
 
 		lock_guard<mutex> lock{ m_lock };
 

--- a/FFmpegInterop/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/FFmpegInteropMSS.cpp
@@ -290,7 +290,7 @@ namespace winrt::FFmpegInterop::implementation
 				// Note: MSS didn't expose subtitle streams in media engine scenarios until 19041.
 				if (!ApiInformation::IsTypePresent(L"Windows.Media.Core.TimedMetadataStreamDescriptor"))
 				{
-					FFMPEG_INTEROP_TRACE("Stream %d: No subtitle support. AVCodecID = %S",
+					FFMPEG_INTEROP_TRACE("Stream %d: No subtitle support. AVCodec Name = %S",
 						stream->index, avcodec_get_name(stream->codecpar->codec_id));
 					continue;
 				}
@@ -302,7 +302,7 @@ namespace winrt::FFmpegInterop::implementation
 				catch (...)
 				{
 					// Unsupported subtitle stream. Just ignore.
-					FFMPEG_INTEROP_TRACE("Stream %d: Unsupported subtitle stream. AVCodecId = %S",
+					FFMPEG_INTEROP_TRACE("Stream %d: Unsupported subtitle stream. AVCodec Name = %S",
 						stream->index, avcodec_get_name(stream->codecpar->codec_id));
 					continue;
 				}
@@ -314,7 +314,7 @@ namespace winrt::FFmpegInterop::implementation
 
 			default:
 				// Ignore this stream
-				FFMPEG_INTEROP_TRACE("Stream %d: Unsupported. AVMediaType = %S, AVCodecID = %S",
+				FFMPEG_INTEROP_TRACE("Stream %d: Unsupported. AVMediaType = %S, AVCodec Name = %S",
 					stream->index, av_get_media_type_string(stream->codecpar->codec_type), avcodec_get_name(stream->codecpar->codec_id));
 				continue;
 			}

--- a/FFmpegInterop/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/FFmpegInteropMSS.cpp
@@ -290,9 +290,8 @@ namespace winrt::FFmpegInterop::implementation
 				// Note: MSS didn't expose subtitle streams in media engine scenarios until 19041.
 				if (!ApiInformation::IsTypePresent(L"Windows.Media.Core.TimedMetadataStreamDescriptor"))
 				{
-					TraceLoggingProviderWrite(FFmpegInteropProvider, "NoSubtitleSupport", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-						TraceLoggingValue(stream->index, "StreamId"),
-						TraceLoggingInt32(stream->codecpar->codec_id, "AVCodecID"));
+					FFMPEG_INTEROP_TRACE("Stream %d: No subtitle support. AVCodecID = %S",
+						stream->index, avcodec_get_name(stream->codecpar->codec_id));
 					continue;
 				}
 
@@ -303,9 +302,8 @@ namespace winrt::FFmpegInterop::implementation
 				catch (...)
 				{
 					// Unsupported subtitle stream. Just ignore.
-					TraceLoggingProviderWrite(FFmpegInteropProvider, "UnsupportedSubtitleStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-						TraceLoggingValue(stream->index, "StreamId"),
-						TraceLoggingInt32(stream->codecpar->codec_id, "AVCodecID"));
+					FFMPEG_INTEROP_TRACE("Stream %d: Unsupported subtitle stream. AVCodecId = %S",
+						stream->index, avcodec_get_name(stream->codecpar->codec_id));
 					continue;
 				}
 
@@ -316,10 +314,8 @@ namespace winrt::FFmpegInterop::implementation
 
 			default:
 				// Ignore this stream
-				TraceLoggingProviderWrite(FFmpegInteropProvider, "UnsupportedStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-					TraceLoggingValue(stream->index, "StreamId"),
-					TraceLoggingInt32(stream->codecpar->codec_type, "AVMediaType"),
-					TraceLoggingInt32(stream->codecpar->codec_id, "AVCodecID"));
+				FFMPEG_INTEROP_TRACE("Stream %d: Unsupported. AVMediaType = %S, AVCodecID = %S",
+					stream->index, av_get_media_type_string(stream->codecpar->codec_type), avcodec_get_name(stream->codecpar->codec_id));
 				continue;
 			}
 
@@ -369,8 +365,7 @@ namespace winrt::FFmpegInterop::implementation
 			lock_guard<mutex> lock{ m_lock };
 
 			const TimeSpan hnsSeekTime{ startPosition.Value() };
-			TraceLoggingProviderWrite(FFmpegInteropProvider, "Seek", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-				TraceLoggingValue(hnsSeekTime.count(), "SeekTimeHNS"));
+			FFMPEG_INTEROP_TRACE("Seek to %I64d hns", hnsSeekTime.count());
 			
 			try
 			{
@@ -403,7 +398,7 @@ namespace winrt::FFmpegInterop::implementation
 		}
 		else
 		{
-			TraceLoggingProviderWrite(FFmpegInteropProvider, "Resume", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"));
+			FFMPEG_INTEROP_TRACE("Resume");
 			logger.Stop();
 		}
 	}

--- a/FFmpegInterop/H264SampleProvider.cpp
+++ b/FFmpegInterop/H264SampleProvider.cpp
@@ -37,7 +37,7 @@ namespace winrt::FFmpegInterop::implementation
 			if (m_stream->codecpar->extradata[0] == 1)
 			{
 				// avcC config format
-				TraceLoggingWrite(g_FFmpegInteropProvider, "AVCCodecPrivate", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+				TraceLoggingProviderWrite(FFmpegInteropProvider, "AVCCodecPrivate", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 					TraceLoggingValue(m_stream->index, "StreamId"));
 
 				m_isBitstreamAnnexB = false;
@@ -49,7 +49,7 @@ namespace winrt::FFmpegInterop::implementation
 			else
 			{
 				// Annex B format
-				TraceLoggingWrite(g_FFmpegInteropProvider, "AnnexBCodecPrivate", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+				TraceLoggingProviderWrite(FFmpegInteropProvider, "AnnexBCodecPrivate", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 					TraceLoggingValue(m_stream->index, "StreamId"));
 
 				AnnexBParser parser{ m_stream->codecpar->extradata, static_cast<uint32_t>(m_stream->codecpar->extradata_size) };
@@ -58,7 +58,7 @@ namespace winrt::FFmpegInterop::implementation
 		}
 		else
 		{
-			TraceLoggingWrite(g_FFmpegInteropProvider, "EmptyCodecPrivate", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+			TraceLoggingProviderWrite(FFmpegInteropProvider, "EmptyCodecPrivate", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 				TraceLoggingValue(m_stream->index, "StreamId"));
 		}
 	}

--- a/FFmpegInterop/H264SampleProvider.cpp
+++ b/FFmpegInterop/H264SampleProvider.cpp
@@ -37,8 +37,7 @@ namespace winrt::FFmpegInterop::implementation
 			if (m_stream->codecpar->extradata[0] == 1)
 			{
 				// avcC config format
-				TraceLoggingProviderWrite(FFmpegInteropProvider, "AVCCodecPrivate", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-					TraceLoggingValue(m_stream->index, "StreamId"));
+				FFMPEG_INTEROP_TRACE("Stream %d: AVC codec private data", m_stream->index);
 
 				m_isBitstreamAnnexB = false;
 
@@ -49,8 +48,7 @@ namespace winrt::FFmpegInterop::implementation
 			else
 			{
 				// Annex B format
-				TraceLoggingProviderWrite(FFmpegInteropProvider, "AnnexBCodecPrivate", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-					TraceLoggingValue(m_stream->index, "StreamId"));
+				FFMPEG_INTEROP_TRACE("Stream %d: Annex B codec private data", m_stream->index);
 
 				AnnexBParser parser{ m_stream->codecpar->extradata, static_cast<uint32_t>(m_stream->codecpar->extradata_size) };
 				tie(m_codecPrivateNaluData, m_codecPrivateNaluLengths) = parser.GetNaluData();
@@ -58,8 +56,7 @@ namespace winrt::FFmpegInterop::implementation
 		}
 		else
 		{
-			TraceLoggingProviderWrite(FFmpegInteropProvider, "EmptyCodecPrivate", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-				TraceLoggingValue(m_stream->index, "StreamId"));
+			FFMPEG_INTEROP_TRACE("Stream %d: No codec private data", m_stream->index);
 		}
 	}
 

--- a/FFmpegInterop/HEVCSampleProvider.cpp
+++ b/FFmpegInterop/HEVCSampleProvider.cpp
@@ -36,8 +36,7 @@ namespace winrt::FFmpegInterop::implementation
 			if (m_stream->codecpar->extradata_size > 3 && (m_stream->codecpar->extradata[0] || m_stream->codecpar->extradata[1] || m_stream->codecpar->extradata[2] > 1))
 			{
 				// hvcC config format
-				TraceLoggingProviderWrite(FFmpegInteropProvider, "HEVCCodecPrivate", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-					TraceLoggingValue(m_stream->index, "StreamId"));
+				FFMPEG_INTEROP_TRACE("Stream %d: HEVC codec private data", m_stream->index);
 
 				m_isBitstreamAnnexB = false;
 
@@ -48,8 +47,7 @@ namespace winrt::FFmpegInterop::implementation
 			else
 			{
 				// Annex B format
-				TraceLoggingProviderWrite(FFmpegInteropProvider, "AnnexBCodecPrivate", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-					TraceLoggingValue(m_stream->index, "StreamId"));
+				FFMPEG_INTEROP_TRACE("Stream %d: Annex B codec private data", m_stream->index);
 
 				AnnexBParser parser{ m_stream->codecpar->extradata, static_cast<uint32_t>(m_stream->codecpar->extradata_size) };
 				tie(m_codecPrivateNaluData, m_codecPrivateNaluLengths) = parser.GetNaluData();

--- a/FFmpegInterop/HEVCSampleProvider.cpp
+++ b/FFmpegInterop/HEVCSampleProvider.cpp
@@ -36,7 +36,7 @@ namespace winrt::FFmpegInterop::implementation
 			if (m_stream->codecpar->extradata_size > 3 && (m_stream->codecpar->extradata[0] || m_stream->codecpar->extradata[1] || m_stream->codecpar->extradata[2] > 1))
 			{
 				// hvcC config format
-				TraceLoggingWrite(g_FFmpegInteropProvider, "HEVCCodecPrivate", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+				TraceLoggingProviderWrite(FFmpegInteropProvider, "HEVCCodecPrivate", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 					TraceLoggingValue(m_stream->index, "StreamId"));
 
 				m_isBitstreamAnnexB = false;
@@ -48,7 +48,7 @@ namespace winrt::FFmpegInterop::implementation
 			else
 			{
 				// Annex B format
-				TraceLoggingWrite(g_FFmpegInteropProvider, "AnnexBCodecPrivate", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+				TraceLoggingProviderWrite(FFmpegInteropProvider, "AnnexBCodecPrivate", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 					TraceLoggingValue(m_stream->index, "StreamId"));
 
 				AnnexBParser parser{ m_stream->codecpar->extradata, static_cast<uint32_t>(m_stream->codecpar->extradata_size) };

--- a/FFmpegInterop/Reader.cpp
+++ b/FFmpegInterop/Reader.cpp
@@ -40,7 +40,7 @@ namespace winrt::FFmpegInterop::implementation
 		// Drop the packet if the stream is not being used.
 		THROW_HR_IF_FFMPEG_FAILED(av_read_frame(m_formatContext, packet.get()));
 
-		TraceLoggingWrite(g_FFmpegInteropProvider, "ReadPacket", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+		TraceLoggingProviderWrite(FFmpegInteropProvider, "ReadPacket", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 			TraceLoggingValue(packet->stream_index, "StreamId"),
 			TraceLoggingValue(packet->pts, "PTS"),
 			TraceLoggingValue(packet->duration, "Dur"),

--- a/FFmpegInterop/Reader.cpp
+++ b/FFmpegInterop/Reader.cpp
@@ -40,11 +40,8 @@ namespace winrt::FFmpegInterop::implementation
 		// Drop the packet if the stream is not being used.
 		THROW_HR_IF_FFMPEG_FAILED(av_read_frame(m_formatContext, packet.get()));
 
-		TraceLoggingProviderWrite(FFmpegInteropProvider, "ReadPacket", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-			TraceLoggingValue(packet->stream_index, "StreamId"),
-			TraceLoggingValue(packet->pts, "PTS"),
-			TraceLoggingValue(packet->duration, "Dur"),
-			TraceLoggingValue(packet->pos, "Pos"));
+		FFMPEG_INTEROP_TRACE("Read packet for Stream %d. PTS = %I64d, Duration = %I64d, Pos = %I64d",
+			packet->stream_index, packet->pts, packet->duration, packet->pos);
 
 		auto iter = m_streamIdMap.find(packet->stream_index);
 		if (iter != m_streamIdMap.end())

--- a/FFmpegInterop/SampleProvider.cpp
+++ b/FFmpegInterop/SampleProvider.cpp
@@ -419,7 +419,7 @@ namespace winrt::FFmpegInterop::implementation
 			FFMPEG_INTEROP_TRACE("Stream %d: Dynamic format change", m_stream->index);
 		}
 
-		FFMPEG_INTEROP_TRACE("Stream %d: Sample request filled. Timestamp = %I64d, Duration = %I64d",
+		FFMPEG_INTEROP_TRACE("Stream %d: Sample request filled. Timestamp = %I64d hns, Duration = %I64d hns",
 			m_stream->index, sample.Timestamp().count(), sample.Duration().count());
 	}
 

--- a/FFmpegInterop/SampleProvider.cpp
+++ b/FFmpegInterop/SampleProvider.cpp
@@ -291,8 +291,7 @@ namespace winrt::FFmpegInterop::implementation
 
 	void SampleProvider::Select() noexcept
 	{
-		TraceLoggingProviderWrite(FFmpegInteropProvider, "StreamSelected", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-			TraceLoggingValue(m_stream->index, "StreamId"));
+		FFMPEG_INTEROP_TRACE("Stream %d: Selected", m_stream->index);
 
 		WINRT_ASSERT(!m_isSelected);
 		m_isSelected = true;
@@ -301,8 +300,7 @@ namespace winrt::FFmpegInterop::implementation
 
 	void SampleProvider::Deselect() noexcept
 	{
-		TraceLoggingProviderWrite(FFmpegInteropProvider, "StreamDeselected", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-			TraceLoggingValue(m_stream->index, "StreamId"));
+		FFMPEG_INTEROP_TRACE("Stream %d: Deselected", m_stream->index);
 
 		WINRT_ASSERT(m_isSelected);
 		m_isSelected = false;
@@ -327,8 +325,7 @@ namespace winrt::FFmpegInterop::implementation
 
 			if (m_isSelected)
 			{
-				TraceLoggingProviderWrite(FFmpegInteropProvider, "EndOfStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-					TraceLoggingValue(m_stream->index, "StreamId"));
+				FFMPEG_INTEROP_TRACE("Stream %d: EOS", m_stream->index);
 			}
 		}
 	}
@@ -349,8 +346,7 @@ namespace winrt::FFmpegInterop::implementation
 
 	void SampleProvider::GetSample(_Inout_ const MediaStreamSourceSampleRequest& request)
 	{
-		TraceLoggingProviderWrite(FFmpegInteropProvider, "SampleRequested", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-			TraceLoggingValue(m_stream->index, "StreamId"));
+		FFMPEG_INTEROP_TRACE("Stream %d: Sample requested", m_stream->index);
 
 		// Make sure this stream is selected
 		THROW_HR_IF(MF_E_INVALIDREQUEST, !m_isSelected);
@@ -420,14 +416,11 @@ namespace winrt::FFmpegInterop::implementation
 				encodingProperties.Insert(key, value);
 			}
 
-			TraceLoggingProviderWrite(FFmpegInteropProvider, "DynamicFormatChange", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-				TraceLoggingValue(m_stream->index, "StreamId"));
+			FFMPEG_INTEROP_TRACE("Stream %d: Dynamic format change", m_stream->index);
 		}
 
-		TraceLoggingProviderWrite(FFmpegInteropProvider, "SampleRequestFilled", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-			TraceLoggingValue(m_stream->index, "StreamId"),
-			TraceLoggingValue(sample.Timestamp().count(), "TimestampHNS"),
-			TraceLoggingValue(sample.Duration().count(), "DurHNS"));
+		FFMPEG_INTEROP_TRACE("Stream %d: Sample request filled. Timestamp = %I64d, Duration = %I64d",
+			m_stream->index, sample.Timestamp().count(), sample.Duration().count());
 	}
 
 	tuple<IBuffer, int64_t, int64_t, vector<pair<GUID, Windows::Foundation::IInspectable>>, vector<pair<GUID, Windows::Foundation::IInspectable>>> SampleProvider::GetSampleData()

--- a/FFmpegInterop/SampleProvider.cpp
+++ b/FFmpegInterop/SampleProvider.cpp
@@ -291,7 +291,7 @@ namespace winrt::FFmpegInterop::implementation
 
 	void SampleProvider::Select() noexcept
 	{
-		TraceLoggingWrite(g_FFmpegInteropProvider, "StreamSelected", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+		TraceLoggingProviderWrite(FFmpegInteropProvider, "StreamSelected", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 			TraceLoggingValue(m_stream->index, "StreamId"));
 
 		WINRT_ASSERT(!m_isSelected);
@@ -301,7 +301,7 @@ namespace winrt::FFmpegInterop::implementation
 
 	void SampleProvider::Deselect() noexcept
 	{
-		TraceLoggingWrite(g_FFmpegInteropProvider, "StreamDeselected", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+		TraceLoggingProviderWrite(FFmpegInteropProvider, "StreamDeselected", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 			TraceLoggingValue(m_stream->index, "StreamId"));
 
 		WINRT_ASSERT(m_isSelected);
@@ -327,7 +327,7 @@ namespace winrt::FFmpegInterop::implementation
 
 			if (m_isSelected)
 			{
-				TraceLoggingWrite(g_FFmpegInteropProvider, "EndOfStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+				TraceLoggingProviderWrite(FFmpegInteropProvider, "EndOfStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 					TraceLoggingValue(m_stream->index, "StreamId"));
 			}
 		}
@@ -349,7 +349,7 @@ namespace winrt::FFmpegInterop::implementation
 
 	void SampleProvider::GetSample(_Inout_ const MediaStreamSourceSampleRequest& request)
 	{
-		TraceLoggingWrite(g_FFmpegInteropProvider, "SampleRequested", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+		TraceLoggingProviderWrite(FFmpegInteropProvider, "SampleRequested", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 			TraceLoggingValue(m_stream->index, "StreamId"));
 
 		// Make sure this stream is selected
@@ -420,11 +420,11 @@ namespace winrt::FFmpegInterop::implementation
 				encodingProperties.Insert(key, value);
 			}
 
-			TraceLoggingWrite(g_FFmpegInteropProvider, "DynamicFormatChange", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+			TraceLoggingProviderWrite(FFmpegInteropProvider, "DynamicFormatChange", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 				TraceLoggingValue(m_stream->index, "StreamId"));
 		}
 
-		TraceLoggingWrite(g_FFmpegInteropProvider, "SampleRequestFilled", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+		TraceLoggingProviderWrite(FFmpegInteropProvider, "SampleRequestFilled", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 			TraceLoggingValue(m_stream->index, "StreamId"),
 			TraceLoggingValue(sample.Timestamp().count(), "TimestampHNS"),
 			TraceLoggingValue(sample.Duration().count(), "DurHNS"));

--- a/FFmpegInterop/StreamFactory.cpp
+++ b/FFmpegInterop/StreamFactory.cpp
@@ -96,13 +96,13 @@ namespace winrt::FFmpegInterop::implementation
 		bool setFormatUserData{ false };
 
 		AVCodecID codecId{ stream->codecpar->codec_id };
-		TraceLoggingWrite(g_FFmpegInteropProvider, "CreateAudioStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
+		TraceLoggingProviderWrite(FFmpegInteropProvider, "CreateAudioStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
 			TraceLoggingValue(stream->index, "StreamId"),
 			TraceLoggingInt32(codecId, "AVCodecID"));
 
 		if (config != nullptr && config.ForceAudioDecode())
 		{
-			TraceLoggingWrite(g_FFmpegInteropProvider, "ForceAudioDecode", TraceLoggingLevel(TRACE_LEVEL_VERBOSE));
+			TraceLoggingProviderWrite(FFmpegInteropProvider, "ForceAudioDecode", TraceLoggingLevel(TRACE_LEVEL_VERBOSE));
 			codecId = AV_CODEC_ID_NONE;
 		}
 
@@ -220,13 +220,13 @@ namespace winrt::FFmpegInterop::implementation
 		bool setFormatUserData{ false };
 
 		AVCodecID codecId{ stream->codecpar->codec_id };
-		TraceLoggingWrite(g_FFmpegInteropProvider, "CreateVideoStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
+		TraceLoggingProviderWrite(FFmpegInteropProvider, "CreateVideoStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
 			TraceLoggingValue(stream->index, "StreamId"),
 			TraceLoggingInt32(codecId, "AVCodecID"));
 
 		if (config != nullptr && config.ForceVideoDecode())
 		{
-			TraceLoggingWrite(g_FFmpegInteropProvider, "ForceVideoDecode", TraceLoggingLevel(TRACE_LEVEL_VERBOSE));
+			TraceLoggingProviderWrite(FFmpegInteropProvider, "ForceVideoDecode", TraceLoggingLevel(TRACE_LEVEL_VERBOSE));
 			codecId = AV_CODEC_ID_NONE;
 		}
 
@@ -320,7 +320,7 @@ namespace winrt::FFmpegInterop::implementation
 		bool setFormatUserData{ false };
 
 		AVCodecID codecId{ stream->codecpar->codec_id };
-		TraceLoggingWrite(g_FFmpegInteropProvider, "CreateSubtitleStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
+		TraceLoggingProviderWrite(FFmpegInteropProvider, "CreateSubtitleStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
 			TraceLoggingValue(stream->index, "StreamId"),
 			TraceLoggingInt32(codecId, "AVCodecID"));
 

--- a/FFmpegInterop/StreamFactory.cpp
+++ b/FFmpegInterop/StreamFactory.cpp
@@ -96,13 +96,11 @@ namespace winrt::FFmpegInterop::implementation
 		bool setFormatUserData{ false };
 
 		AVCodecID codecId{ stream->codecpar->codec_id };
-		TraceLoggingProviderWrite(FFmpegInteropProvider, "CreateAudioStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
-			TraceLoggingValue(stream->index, "StreamId"),
-			TraceLoggingInt32(codecId, "AVCodecID"));
+		FFMPEG_INTEROP_TRACE("Stream %d: New audio stream. AVCodecID = %S", stream->index, avcodec_get_name(codecId));
 
 		if (config != nullptr && config.ForceAudioDecode())
 		{
-			TraceLoggingProviderWrite(FFmpegInteropProvider, "ForceAudioDecode", TraceLoggingLevel(TRACE_LEVEL_VERBOSE));
+			FFMPEG_INTEROP_TRACE("Forcing audio decode");
 			codecId = AV_CODEC_ID_NONE;
 		}
 
@@ -220,13 +218,11 @@ namespace winrt::FFmpegInterop::implementation
 		bool setFormatUserData{ false };
 
 		AVCodecID codecId{ stream->codecpar->codec_id };
-		TraceLoggingProviderWrite(FFmpegInteropProvider, "CreateVideoStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
-			TraceLoggingValue(stream->index, "StreamId"),
-			TraceLoggingInt32(codecId, "AVCodecID"));
+		FFMPEG_INTEROP_TRACE("Stream %d: New video stream. AVCodecID = %S", stream->index, avcodec_get_name(codecId));
 
 		if (config != nullptr && config.ForceVideoDecode())
 		{
-			TraceLoggingProviderWrite(FFmpegInteropProvider, "ForceVideoDecode", TraceLoggingLevel(TRACE_LEVEL_VERBOSE));
+			FFMPEG_INTEROP_TRACE("Forcing video decode");
 			codecId = AV_CODEC_ID_NONE;
 		}
 
@@ -320,9 +316,7 @@ namespace winrt::FFmpegInterop::implementation
 		bool setFormatUserData{ false };
 
 		AVCodecID codecId{ stream->codecpar->codec_id };
-		TraceLoggingProviderWrite(FFmpegInteropProvider, "CreateSubtitleStream", TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
-			TraceLoggingValue(stream->index, "StreamId"),
-			TraceLoggingInt32(codecId, "AVCodecID"));
+		FFMPEG_INTEROP_TRACE("Stream %d: New subtitle stream. AVCodecID = %S", stream->index, avcodec_get_name(codecId));
 
 		switch (codecId)
 		{

--- a/FFmpegInterop/StreamFactory.cpp
+++ b/FFmpegInterop/StreamFactory.cpp
@@ -96,7 +96,7 @@ namespace winrt::FFmpegInterop::implementation
 		bool setFormatUserData{ false };
 
 		AVCodecID codecId{ stream->codecpar->codec_id };
-		FFMPEG_INTEROP_TRACE("Stream %d: New audio stream. AVCodecID = %S", stream->index, avcodec_get_name(codecId));
+		FFMPEG_INTEROP_TRACE("Stream %d: New audio stream. AVCodec Name = %S", stream->index, avcodec_get_name(codecId));
 
 		if (config != nullptr && config.ForceAudioDecode())
 		{
@@ -218,7 +218,7 @@ namespace winrt::FFmpegInterop::implementation
 		bool setFormatUserData{ false };
 
 		AVCodecID codecId{ stream->codecpar->codec_id };
-		FFMPEG_INTEROP_TRACE("Stream %d: New video stream. AVCodecID = %S", stream->index, avcodec_get_name(codecId));
+		FFMPEG_INTEROP_TRACE("Stream %d: New video stream. AVCodec Name = %S", stream->index, avcodec_get_name(codecId));
 
 		if (config != nullptr && config.ForceVideoDecode())
 		{
@@ -316,7 +316,7 @@ namespace winrt::FFmpegInterop::implementation
 		bool setFormatUserData{ false };
 
 		AVCodecID codecId{ stream->codecpar->codec_id };
-		FFMPEG_INTEROP_TRACE("Stream %d: New subtitle stream. AVCodecID = %S", stream->index, avcodec_get_name(codecId));
+		FFMPEG_INTEROP_TRACE("Stream %d: New subtitle stream. AVCodec Name = %S", stream->index, avcodec_get_name(codecId));
 
 		switch (codecId)
 		{

--- a/FFmpegInterop/SubtitleSampleProvider.cpp
+++ b/FFmpegInterop/SubtitleSampleProvider.cpp
@@ -37,7 +37,7 @@ namespace winrt::FFmpegInterop::implementation
 		// If we're at EOS now, complete any deferred sample request
 		if (m_isEOS && m_sampleRequestDeferral != nullptr)
 		{
-			TraceLoggingWrite(g_FFmpegInteropProvider, "DeferredSubtitleSampleRequestFilledEOS", TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
+			TraceLoggingProviderWrite(FFmpegInteropProvider, "DeferredSubtitleSampleRequestFilledEOS", TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
 				TraceLoggingValue(m_stream->index, "StreamId"));
 
 			m_sampleRequestDeferral.Complete();
@@ -53,7 +53,7 @@ namespace winrt::FFmpegInterop::implementation
 		// Drop any outstanding sample request
 		if (m_sampleRequestDeferral != nullptr)
 		{
-			TraceLoggingWrite(g_FFmpegInteropProvider, "DeferredSubtitleSampleRequestDropped", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+			TraceLoggingProviderWrite(FFmpegInteropProvider, "DeferredSubtitleSampleRequestDropped", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 				TraceLoggingValue(m_stream->index, "StreamId"));
 
 			m_sampleRequest = nullptr;
@@ -74,7 +74,7 @@ namespace winrt::FFmpegInterop::implementation
 			m_sampleRequest = nullptr;
 			m_sampleRequestDeferral = nullptr;
 
-			TraceLoggingWrite(g_FFmpegInteropProvider, "DeferredSubtitleSampleRequestFilled", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+			TraceLoggingProviderWrite(FFmpegInteropProvider, "DeferredSubtitleSampleRequestFilled", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 				TraceLoggingValue(m_stream->index, "StreamId"));
 		}
 	}
@@ -97,7 +97,7 @@ namespace winrt::FFmpegInterop::implementation
 			m_sampleRequest = request;
 			m_sampleRequestDeferral = request.GetDeferral();
 
-			TraceLoggingWrite(g_FFmpegInteropProvider, "DeferredSubtitleSampleRequest", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+			TraceLoggingProviderWrite(FFmpegInteropProvider, "DeferredSubtitleSampleRequest", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 				TraceLoggingValue(m_stream->index, "StreamId"));
 		}
 	}

--- a/FFmpegInterop/SubtitleSampleProvider.cpp
+++ b/FFmpegInterop/SubtitleSampleProvider.cpp
@@ -37,8 +37,7 @@ namespace winrt::FFmpegInterop::implementation
 		// If we're at EOS now, complete any deferred sample request
 		if (m_isEOS && m_sampleRequestDeferral != nullptr)
 		{
-			TraceLoggingProviderWrite(FFmpegInteropProvider, "DeferredSubtitleSampleRequestFilledEOS", TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
-				TraceLoggingValue(m_stream->index, "StreamId"));
+			FFMPEG_INTEROP_TRACE("Stream %d: Deferred subtitle sample request filled due to EOS", m_stream->index);
 
 			m_sampleRequestDeferral.Complete();
 			m_sampleRequest = nullptr;
@@ -53,8 +52,7 @@ namespace winrt::FFmpegInterop::implementation
 		// Drop any outstanding sample request
 		if (m_sampleRequestDeferral != nullptr)
 		{
-			TraceLoggingProviderWrite(FFmpegInteropProvider, "DeferredSubtitleSampleRequestDropped", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-				TraceLoggingValue(m_stream->index, "StreamId"));
+			FFMPEG_INTEROP_TRACE("Stream %d: Deferred subtitle sample request dropped", m_stream->index);
 
 			m_sampleRequest = nullptr;
 			m_sampleRequestDeferral = nullptr;
@@ -74,8 +72,7 @@ namespace winrt::FFmpegInterop::implementation
 			m_sampleRequest = nullptr;
 			m_sampleRequestDeferral = nullptr;
 
-			TraceLoggingProviderWrite(FFmpegInteropProvider, "DeferredSubtitleSampleRequestFilled", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-				TraceLoggingValue(m_stream->index, "StreamId"));
+			FFMPEG_INTEROP_TRACE("Stream %d: Deferred subtitle sample request filled", m_stream->index);
 		}
 	}
 
@@ -97,8 +94,7 @@ namespace winrt::FFmpegInterop::implementation
 			m_sampleRequest = request;
 			m_sampleRequestDeferral = request.GetDeferral();
 
-			TraceLoggingProviderWrite(FFmpegInteropProvider, "DeferredSubtitleSampleRequest", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-				TraceLoggingValue(m_stream->index, "StreamId"));
+			FFMPEG_INTEROP_TRACE("Stream %d: Deferred subtitle sample request", m_stream->index);
 		}
 	}
 }

--- a/FFmpegInterop/Tracing.cpp
+++ b/FFmpegInterop/Tracing.cpp
@@ -21,9 +21,8 @@
 
 namespace winrt::FFmpegInterop::implementation
 {
-	// {3D64F3FC-1826-4F56-9688-AD139DAF7B1A}
 	TRACELOGGING_DEFINE_PROVIDER(
 		g_FFmpegInteropProvider,
-		"FFmpegInterop",
-		(0x3d64f3fc, 0x1826, 0x4f56, 0x96, 0x88, 0xad, 0x13, 0x9d, 0xaf, 0x7b, 0x1a));
+		FFMPEG_INTEROP_PROVIDER_NAME,
+		FFMPEG_INTEROP_PROVIDER_GUID);
 }

--- a/FFmpegInterop/Tracing.h
+++ b/FFmpegInterop/Tracing.h
@@ -18,13 +18,13 @@
 
 #pragma once
 
-#define FFMPEG_INTEROP_PROVIDER_NAME "Microsoft.Windows.MediaFoundation.FFmpegInterop"
-// {3D64F3FC-1826-4F56-9688-AD139DAF7B1A}
-#define FFMPEG_INTEROP_PROVIDER_GUID (0x3d64f3fc, 0x1826, 0x4f56, 0x96, 0x88, 0xad, 0x13, 0x9d, 0xaf, 0x7b, 0x1a)
-
 namespace winrt::FFmpegInterop::implementation
 {
 	TRACELOGGING_DECLARE_PROVIDER(g_FFmpegInteropProvider);
+
+#define FFMPEG_INTEROP_PROVIDER_NAME "Microsoft.Windows.MediaFoundation.FFmpegInterop"
+// {3D64F3FC-1826-4F56-9688-AD139DAF7B1A}
+#define FFMPEG_INTEROP_PROVIDER_GUID (0x3d64f3fc, 0x1826, 0x4f56, 0x96, 0x88, 0xad, 0x13, 0x9d, 0xaf, 0x7b, 0x1a)
 
 	class FFmpegInteropProvider : 
 		public wil::TraceLoggingProvider
@@ -42,4 +42,20 @@ namespace winrt::FFmpegInterop::implementation
 		DEFINE_TRACELOGGING_ACTIVITY(OnSwitchStreamsRequested);
 		DEFINE_TRACELOGGING_ACTIVITY(OnClosed);
 	};
+
+// Strip path from __FILE__
+#define FILENAME(file) std::string_view(file).substr(std::string_view(file).rfind('\\') + 1).data()
+
+#define FFMPEG_INTEROP_TRACE(message, ...) \
+__if_exists(__identifier(this)) \
+{ \
+	FFmpegInteropProvider::TraceLoggingInfo("(%S%d) %S@0x%p: " message, \
+		FILENAME(__FILE__), __LINE__, __func__, this, __VA_ARGS__) \
+} \
+__if_not_exists(__identifier(this)) \
+{ \
+	FFmpegInteropProvider::TraceLoggingInfo("(%S%d) %S: " message, \
+		FILENAME(__FILE__), __LINE__, __func__, __VA_ARGS__) \
+} \
+
 }

--- a/FFmpegInterop/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedAudioSampleProvider.cpp
@@ -139,7 +139,7 @@ namespace winrt::FFmpegInterop::implementation
 					if (decodeErrors < m_allowedDecodeErrors)
 					{
 						decodeErrors++;
-						TraceLoggingWrite(g_FFmpegInteropProvider, "AllowedDecodeError", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+						TraceLoggingProviderWrite(FFmpegInteropProvider, "AllowedDecodeError", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 							TraceLoggingValue(m_stream->index, "StreamId"),
 							TraceLoggingValue(decodeErrors, "DecodeErrorCount"),
 							TraceLoggingValue(m_allowedDecodeErrors, "DecodeErrorLimit"));
@@ -306,7 +306,7 @@ namespace winrt::FFmpegInterop::implementation
 			else
 			{
 				// Continue compacting samples
-				TraceLoggingWrite(g_FFmpegInteropProvider, "CompactingUncompressedAudioSamples", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+				TraceLoggingProviderWrite(FFmpegInteropProvider, "CompactingUncompressedAudioSamples", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 					TraceLoggingValue(m_stream->index, "StreamId"),
 					TraceLoggingValue(dur, "CompactedDur"));
 

--- a/FFmpegInterop/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedAudioSampleProvider.cpp
@@ -139,10 +139,8 @@ namespace winrt::FFmpegInterop::implementation
 					if (decodeErrors < m_allowedDecodeErrors)
 					{
 						decodeErrors++;
-						TraceLoggingProviderWrite(FFmpegInteropProvider, "AllowedDecodeError", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-							TraceLoggingValue(m_stream->index, "StreamId"),
-							TraceLoggingValue(decodeErrors, "DecodeErrorCount"),
-							TraceLoggingValue(m_allowedDecodeErrors, "DecodeErrorLimit"));
+						FFMPEG_INTEROP_TRACE("Stream %d: Decode error. Total decoder errors = %d, Limit = %d",
+							m_stream->index, decodeErrors, m_allowedDecodeErrors);
 
 						if (firstDecodedSample)
 						{
@@ -306,9 +304,8 @@ namespace winrt::FFmpegInterop::implementation
 			else
 			{
 				// Continue compacting samples
-				TraceLoggingProviderWrite(FFmpegInteropProvider, "CompactingUncompressedAudioSamples", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-					TraceLoggingValue(m_stream->index, "StreamId"),
-					TraceLoggingValue(dur, "CompactedDur"));
+				FFMPEG_INTEROP_TRACE("Stream %d: Compacting uncompressed audio samples. Compacted Duration = %I64d",
+					m_stream->index, dur);
 
 				firstDecodedSample = false;
 			}

--- a/FFmpegInterop/UncompressedSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedSampleProvider.cpp
@@ -92,7 +92,7 @@ namespace winrt::FFmpegInterop::implementation
 			if (decodeResult == AVERROR(EAGAIN))
 			{
 				// The decoder needs more data to produce a frame
-				TraceLoggingWrite(g_FFmpegInteropProvider, "DecoderNeedsMoreInput", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+				TraceLoggingProviderWrite(FFmpegInteropProvider, "DecoderNeedsMoreInput", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 					TraceLoggingValue(m_stream->index, "StreamId"));
 
 				m_sendInput = true;
@@ -100,7 +100,7 @@ namespace winrt::FFmpegInterop::implementation
 			}
 			THROW_HR_IF_FFMPEG_FAILED(decodeResult);
 
-			TraceLoggingWrite(g_FFmpegInteropProvider, "FrameDecoded", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+			TraceLoggingProviderWrite(FFmpegInteropProvider, "FrameDecoded", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 				TraceLoggingValue(m_stream->index, "StreamId"));
 			return frame;
 		}

--- a/FFmpegInterop/UncompressedSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedSampleProvider.cpp
@@ -92,16 +92,14 @@ namespace winrt::FFmpegInterop::implementation
 			if (decodeResult == AVERROR(EAGAIN))
 			{
 				// The decoder needs more data to produce a frame
-				TraceLoggingProviderWrite(FFmpegInteropProvider, "DecoderNeedsMoreInput", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-					TraceLoggingValue(m_stream->index, "StreamId"));
+				FFMPEG_INTEROP_TRACE("Stream %d: Decoder needs more input", m_stream->index);
 
 				m_sendInput = true;
 				continue;
 			}
 			THROW_HR_IF_FFMPEG_FAILED(decodeResult);
 
-			TraceLoggingProviderWrite(FFmpegInteropProvider, "FrameDecoded", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-				TraceLoggingValue(m_stream->index, "StreamId"));
+			FFMPEG_INTEROP_TRACE("Stream %d: Frame decoded", m_stream->index);
 			return frame;
 		}
 	}

--- a/FFmpegInterop/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.cpp
@@ -108,7 +108,7 @@ namespace winrt::FFmpegInterop::implementation
 					if (decodeErrors < m_allowedDecodeErrors)
 					{
 						decodeErrors++;
-						TraceLoggingWrite(g_FFmpegInteropProvider, "AllowedDecodeError", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+						TraceLoggingProviderWrite(FFmpegInteropProvider, "AllowedDecodeError", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 							TraceLoggingValue(m_stream->index, "StreamId"),
 							TraceLoggingValue(decodeErrors, "DecodeErrorCount"),
 							TraceLoggingValue(m_allowedDecodeErrors, "DecodeErrorLimit"));
@@ -164,7 +164,7 @@ namespace winrt::FFmpegInterop::implementation
 		// Check if the resolution changed
 		if (frame->width != m_outputWidth || frame->height != m_outputHeight)
 		{
-			TraceLoggingWrite(g_FFmpegInteropProvider, "ResolutionChanged", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
+			TraceLoggingProviderWrite(FFmpegInteropProvider, "ResolutionChanged", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
 				TraceLoggingValue(m_stream->index, "StreamId"),
 				TraceLoggingValue(m_outputWidth, "OldWidth"),
 				TraceLoggingValue(m_outputHeight, "OldHeight"),

--- a/FFmpegInterop/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.cpp
@@ -108,10 +108,8 @@ namespace winrt::FFmpegInterop::implementation
 					if (decodeErrors < m_allowedDecodeErrors)
 					{
 						decodeErrors++;
-						TraceLoggingProviderWrite(FFmpegInteropProvider, "AllowedDecodeError", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-							TraceLoggingValue(m_stream->index, "StreamId"),
-							TraceLoggingValue(decodeErrors, "DecodeErrorCount"),
-							TraceLoggingValue(m_allowedDecodeErrors, "DecodeErrorLimit"));
+						FFMPEG_INTEROP_TRACE("Stream %d: Decode error. Total decoder errors = %d, Limit = %d",
+							m_stream->index, decodeErrors, m_allowedDecodeErrors);
 
 						m_isDiscontinuous = true;
 					}
@@ -164,12 +162,8 @@ namespace winrt::FFmpegInterop::implementation
 		// Check if the resolution changed
 		if (frame->width != m_outputWidth || frame->height != m_outputHeight)
 		{
-			TraceLoggingProviderWrite(FFmpegInteropProvider, "ResolutionChanged", TraceLoggingLevel(TRACE_LEVEL_VERBOSE), TraceLoggingPointer(this, "this"),
-				TraceLoggingValue(m_stream->index, "StreamId"),
-				TraceLoggingValue(m_outputWidth, "OldWidth"),
-				TraceLoggingValue(m_outputHeight, "OldHeight"),
-				TraceLoggingValue(frame->width, "NewWidth"),
-				TraceLoggingValue(frame->height, "NewHeight"));
+			FFMPEG_INTEROP_TRACE("Stream %d: Resolution change. Old Width = %d, Old Height = %d, New Width = %d, New Height = %d",
+				m_stream->index, m_outputWidth, m_outputHeight, frame->width, frame->height);
 
 			m_outputWidth = frame->width;
 			m_outputHeight = frame->height;

--- a/FFmpegInterop/Utility.h
+++ b/FFmpegInterop/Utility.h
@@ -83,6 +83,8 @@ namespace winrt::FFmpegInterop::implementation
 			return MF_E_BUFFERTOOSMALL;
 		case AVERROR_EOF:
 			return MF_E_END_OF_STREAM;
+		case AVERROR_INVALIDDATA:
+			return MF_E_INVALID_FILE_FORMAT;
 		default:
 			return E_FAIL;
 		}

--- a/FFmpegInterop/Utility.h
+++ b/FFmpegInterop/Utility.h
@@ -102,6 +102,8 @@ namespace winrt::FFmpegInterop::implementation
 		const int __status = verify_averror(status); \
 		if (__status < 0) \
 		{ \
+		 	char buf[AV_ERROR_MAX_STRING_SIZE]{0}; \
+			FFMPEG_INTEROP_TRACE("FFmpeg failed: %S", av_make_error_string(buf, AV_ERROR_MAX_STRING_SIZE, __status)); \
 			THROW_HR_MSG(averror_to_hresult(__status), #status); \
 		} \
 	} while (false) \

--- a/FFmpegInterop/packages.config
+++ b/FFmpegInterop/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.230824.2" targetFramework="native" />
 </packages>

--- a/FFmpegInterop/pch.h
+++ b/FFmpegInterop/pch.h
@@ -41,9 +41,6 @@
 
 // Windows
 #include <Windows.h>
-#include <evntrace.h>
-#include <TraceLoggingProvider.h>
-#include <TraceLoggingActivity.h>
 #include <shcore.h>
 
 // MF

--- a/FFmpegInterop/pch.h
+++ b/FFmpegInterop/pch.h
@@ -27,6 +27,7 @@
 // WIL
 #include <wil/cppwinrt.h>
 #include <wil/result.h>
+#include <wil/Tracelogging.h>
 
 // WinRT
 #include <winrt/base.h>

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -181,15 +181,15 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/Samples/MediaPlayerCPP/Package.appxmanifest
+++ b/Samples/MediaPlayerCPP/Package.appxmanifest
@@ -25,7 +25,7 @@
   IgnorableNamespaces="uap mp">
 
   <Identity
-    Name="c08bc68a-b511-4abc-8b98-067f25611588"
+    Name="MediaPlayerCPP"
     Publisher="CN=FFmpegInterop"
     Version="1.0.0.0" />
 
@@ -46,7 +46,7 @@
   </Resources>
 
   <Applications>
-    <Application Id="App"
+    <Application Id="MediaPlayerCPP"
       Executable="$targetnametoken$.exe"
       EntryPoint="MediaPlayerCPP.App">
       <uap:VisualElements

--- a/Samples/MediaPlayerCPP/packages.config
+++ b/Samples/MediaPlayerCPP/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.221121.5" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.230824.2" targetFramework="native" />
 </packages>

--- a/Samples/MediaPlayerCS/App.xaml.cs
+++ b/Samples/MediaPlayerCS/App.xaml.cs
@@ -46,7 +46,7 @@ namespace MediaPlayerCS
 
         public static void Log(object sender, FFmpegInterop.LogEventArgs args)
         {
-            System.Diagnostics.Debug.WriteLine("FFmpeg ({0}): {1}", args.Level, args.Message);
+            System.Diagnostics.Debug.Write(args.Message);
         }
 
         /// <summary>

--- a/Samples/MediaPlayerCS/Package.appxmanifest
+++ b/Samples/MediaPlayerCS/Package.appxmanifest
@@ -7,7 +7,7 @@
   IgnorableNamespaces="uap mp">
 
   <Identity
-    Name="5388ef25-5c75-440f-a383-14d03f338feb"
+    Name="MediaPlayerCS"
     Publisher="CN=FFmpegInterop"
     Version="1.0.0.0" />
 
@@ -28,7 +28,7 @@
   </Resources>
 
   <Applications>
-    <Application Id="App"
+    <Application Id="MediaPlayerCS"
       Executable="$targetnametoken$.exe"
       EntryPoint="MediaPlayerCS.App">
       <uap:VisualElements

--- a/Tests/UnitTest.csproj
+++ b/Tests/UnitTest.csproj
@@ -163,13 +163,13 @@
       <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>3.0.2</Version>
+      <Version>3.1.1</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.0.2</Version>
+      <Version>3.1.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.2</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="System.Xml.XPath.XmlDocument">
       <Version>4.3.0</Version>


### PR DESCRIPTION
## Why is this change being made?
We want to improve tracing to get better diagnostics for future bug investigations.

## What changed?
- Update packages
- Update to C++ 20
- Switch to using WIL's TraceLogging helpers for tracing now that they're public
- Add a custom trace macro that wraps wil::TraceLoggingProvider::TraceLoggingInfo() to provide printf-style logging with a prefix that includes file, line, function, and "this" (if it exists)

## How was the change tested?
I validated Ogg playback in:
- MediaPlayerCPP
- MediaPlayerCS
- Media Player with WME

I verified that trace logging and FFmpegInteropLogging work as expected.