### PR TITLE
MSFT: 47925856 - Update to FFmpeg 6.1.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ffmpeg"]
 	path = ffmpeg
 	url = https://github.com/FFmpeg/FFmpeg.git
-	branch = release/6.0
+	branch = release/6.1

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -187,15 +187,15 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/FFmpegInterop/SampleProvider.cpp
+++ b/FFmpegInterop/SampleProvider.cpp
@@ -233,7 +233,7 @@ namespace winrt::FFmpegInterop::implementation
 			const AVPacketSideData* sideData{ av_packet_side_data_get(m_stream->codecpar->coded_side_data, m_stream->codecpar->nb_coded_side_data, AV_PKT_DATA_CONTENT_LIGHT_LEVEL) };
 			if (sideData != nullptr)
 			{
-				AVContentLightMetadata* contentLightMetadata{ reinterpret_cast<AVContentLightMetadata*>(sideData->data) };
+				auto contentLightMetadata{ reinterpret_cast<const AVContentLightMetadata*>(sideData->data) };
 				properties.Insert(MF_MT_MAX_LUMINANCE_LEVEL, PropertyValue::CreateUInt32(contentLightMetadata->MaxCLL));
 				properties.Insert(MF_MT_MAX_FRAME_AVERAGE_LUMINANCE_LEVEL, PropertyValue::CreateUInt32(contentLightMetadata->MaxFALL));
 			}
@@ -241,7 +241,7 @@ namespace winrt::FFmpegInterop::implementation
 			sideData = av_packet_side_data_get(m_stream->codecpar->coded_side_data, m_stream->codecpar->nb_coded_side_data, AV_PKT_DATA_MASTERING_DISPLAY_METADATA);
 			if (sideData != nullptr)
 			{
-				AVMasteringDisplayMetadata* masteringDisplayMetadata{ reinterpret_cast<AVMasteringDisplayMetadata*>(sideData->data) };
+				auto masteringDisplayMetadata{ reinterpret_cast<const AVMasteringDisplayMetadata*>(sideData->data) };
 				if (masteringDisplayMetadata->has_luminance)
 				{
 					constexpr uint32_t MASTERING_DISP_LUMINANCE_SCALE{ 10000 };

--- a/FFmpegInterop/SampleProvider.cpp
+++ b/FFmpegInterop/SampleProvider.cpp
@@ -230,14 +230,18 @@ namespace winrt::FFmpegInterop::implementation
 				properties.Insert(MF_MT_VIDEO_NOMINAL_RANGE, PropertyValue::CreateUInt32(nominalRange));
 			}
 
-			if (AVContentLightMetadata* contentLightMetadata{ reinterpret_cast<AVContentLightMetadata*>(av_stream_get_side_data(m_stream, AV_PKT_DATA_CONTENT_LIGHT_LEVEL, nullptr)) }; contentLightMetadata != nullptr)
+			const AVPacketSideData* sideData{ av_packet_side_data_get(m_stream->codecpar->coded_side_data, m_stream->codecpar->nb_coded_side_data, AV_PKT_DATA_CONTENT_LIGHT_LEVEL) };
+			if (sideData != nullptr)
 			{
+				AVContentLightMetadata* contentLightMetadata{ reinterpret_cast<AVContentLightMetadata*>(sideData->data) };
 				properties.Insert(MF_MT_MAX_LUMINANCE_LEVEL, PropertyValue::CreateUInt32(contentLightMetadata->MaxCLL));
 				properties.Insert(MF_MT_MAX_FRAME_AVERAGE_LUMINANCE_LEVEL, PropertyValue::CreateUInt32(contentLightMetadata->MaxFALL));
 			}
 
-			if (AVMasteringDisplayMetadata* masteringDisplayMetadata{ reinterpret_cast<AVMasteringDisplayMetadata*>(av_stream_get_side_data(m_stream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, nullptr)) }; masteringDisplayMetadata != nullptr)
+			sideData = av_packet_side_data_get(m_stream->codecpar->coded_side_data, m_stream->codecpar->nb_coded_side_data, AV_PKT_DATA_MASTERING_DISPLAY_METADATA);
+			if (sideData != nullptr)
 			{
+				AVMasteringDisplayMetadata* masteringDisplayMetadata{ reinterpret_cast<AVMasteringDisplayMetadata*>(sideData->data) };
 				if (masteringDisplayMetadata->has_luminance)
 				{
 					constexpr uint32_t MASTERING_DISP_LUMINANCE_SCALE{ 10000 };

--- a/FFmpegInterop/SampleProvider.cpp
+++ b/FFmpegInterop/SampleProvider.cpp
@@ -233,7 +233,9 @@ namespace winrt::FFmpegInterop::implementation
 			const AVPacketSideData* sideData{ av_packet_side_data_get(m_stream->codecpar->coded_side_data, m_stream->codecpar->nb_coded_side_data, AV_PKT_DATA_CONTENT_LIGHT_LEVEL) };
 			if (sideData != nullptr)
 			{
+				WINRT_ASSERT(sideData->size == sizeof(AVContentLightMetadata));
 				auto contentLightMetadata{ reinterpret_cast<const AVContentLightMetadata*>(sideData->data) };
+
 				properties.Insert(MF_MT_MAX_LUMINANCE_LEVEL, PropertyValue::CreateUInt32(contentLightMetadata->MaxCLL));
 				properties.Insert(MF_MT_MAX_FRAME_AVERAGE_LUMINANCE_LEVEL, PropertyValue::CreateUInt32(contentLightMetadata->MaxFALL));
 			}
@@ -241,7 +243,9 @@ namespace winrt::FFmpegInterop::implementation
 			sideData = av_packet_side_data_get(m_stream->codecpar->coded_side_data, m_stream->codecpar->nb_coded_side_data, AV_PKT_DATA_MASTERING_DISPLAY_METADATA);
 			if (sideData != nullptr)
 			{
+				WINRT_ASSERT(sideData->size == sizeof(AVMasteringDisplayMetadata));
 				auto masteringDisplayMetadata{ reinterpret_cast<const AVMasteringDisplayMetadata*>(sideData->data) };
+
 				if (masteringDisplayMetadata->has_luminance)
 				{
 					constexpr uint32_t MASTERING_DISP_LUMINANCE_SCALE{ 10000 };

--- a/FFmpegInterop/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.cpp
@@ -182,10 +182,10 @@ namespace winrt::FFmpegInterop::implementation
 	{
 		vector<pair<GUID, Windows::Foundation::IInspectable>> properties;
 
-		if (frame->interlaced_frame)
+		if ((frame->flags & AV_FRAME_FLAG_INTERLACED) != 0)
 		{
 			properties.emplace_back(MFSampleExtension_Interlaced, PropertyValue::CreateUInt32(true));
-			properties.emplace_back(MFSampleExtension_BottomFieldFirst, PropertyValue::CreateUInt32(!frame->top_field_first));
+			properties.emplace_back(MFSampleExtension_BottomFieldFirst, PropertyValue::CreateUInt32((frame->flags & AV_FRAME_FLAG_TOP_FIELD_FIRST) == 0));
 			properties.emplace_back(MFSampleExtension_RepeatFirstField, PropertyValue::CreateUInt32(false));
 		}
 		else

--- a/FFmpegInterop/packages.config
+++ b/FFmpegInterop/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.230824.2" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.240111.5" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
 </packages>

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -181,15 +181,15 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/Samples/MediaPlayerCPP/packages.config
+++ b/Samples/MediaPlayerCPP/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.230824.2" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.240111.5" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
## Why is this change being made?
We're updating to the latest version of FFmpeg.

## What changed?
- Updated to FFmpeg [6.1.1](https://github.com/FFmpeg/FFmpeg/releases/tag/n6.1.1)
  - av_stream_get_side_data() was deprecated. Use av_packet_side_data_get() with AVStream::codecpar.coded_side_data instead.
  - AVFrame::interlaced_frame/AVFrame::top_field_first were deprecated. Use AVFrame::flags with AV_FRAME_FLAG_INTERLACED/AV_FRAME_FLAG_TOP_FIELD_FIRST instead.
- Updated packages to the latest versions

## How was the change tested?
I validated the following scenarios:
- Playback in MediaPlayerCPP
  - Ogg
  - MKV
- Playback in Media Player with WME
  - Ogg
  - MKV with Vorbis/Theora
- Ogg properties in File Explorer with WME