### PR TITLE
MSFT: 49309119 - Reduce FFmpegInterop's storage footprint

### DIFF
--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -92,7 +92,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
-      <AdditionalDependencies>avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib;mfplat.lib;mfuuid.lib;wmcodecdspuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>avcodec.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib;mfplat.lib;mfuuid.lib;wmcodecdspuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ProjectDir)..\ffmpeg\Build\$(PlatformTarget)\bin;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>FFmpegInterop.def</ModuleDefinitionFile>
     </Link>

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -85,9 +85,9 @@
       <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
-      <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(ProjectDir)..\ffmpeg\Build\$(PlatformTarget)\include;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -109,10 +109,16 @@
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
+      <Optimization>MinSpace</Optimization>
+      <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
+      <StringPooling>true</StringPooling>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
     </ClCompile>
     <Link>
       <AdditionalOptions>/GUARD:CF %(AdditionalOptions)</AdditionalOptions>
       <Profile>true</Profile>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -159,12 +159,6 @@
     <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avcodec-60_ms.dll">
       <DeploymentContent>true</DeploymentContent>
     </None>
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avdevice-60_ms.dll">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avfilter-9_ms.dll">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
     <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avformat-60_ms.dll">
       <DeploymentContent>true</DeploymentContent>
     </None>

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj.filters
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj.filters
@@ -53,8 +53,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avcodec-58_ms.dll" />
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avdevice-58_ms.dll" />
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avfilter-7_ms.dll" />
     <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avformat-58_ms.dll" />
     <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avutil-56_ms.dll" />
     <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\swresample-3_ms.dll" />


### PR DESCRIPTION
## Why is this change being made?
We want to reduce FFmpegInterop's storage footprint.

## What changed?
- Enable compiler and linker optimizations for favoring small code size
- Remove unnecessary dependencies on avdevice and avfilter

## How was the change tested?
I validated the following scenarios:
- Ogg playback in MediaPlayerCPP
- Ogg playback in Media Player with WME
- Ogg properties in File Explorer with WME