### PR TITLE
MSFT: 49847737 - FFmpegInteropBuffer is leaking its underlying buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,7 +255,7 @@ paket-files/
 *.sln.iml
 
 # VS Code
-.vscode/*
+.vscode/
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json

--- a/FFmpegInterop/FFmpegInteropBuffer.cpp
+++ b/FFmpegInterop/FFmpegInteropBuffer.cpp
@@ -24,8 +24,8 @@ using namespace std;
 namespace winrt::FFmpegInterop::implementation
 {
 	FFmpegInteropBuffer::FFmpegInteropBuffer(_In_ AVBufferRef* bufRef) :
-		m_length(static_cast<uint32_t>(bufRef->size)),
-		m_buf(reinterpret_cast<uint8_t*>(bufRef->data))
+		m_buf(reinterpret_cast<uint8_t*>(bufRef->data)),
+		m_length(static_cast<uint32_t>(bufRef->size))
 	{
 		THROW_HR_IF(E_INVALIDARG, bufRef->size > numeric_limits<uint32_t>::max());
 
@@ -35,8 +35,8 @@ namespace winrt::FFmpegInterop::implementation
 	}
 
 	FFmpegInteropBuffer::FFmpegInteropBuffer(_In_ AVBufferRef_ptr bufRef) :
-		m_length(static_cast<uint32_t>(bufRef->size)),
-		m_buf(reinterpret_cast<uint8_t*>(bufRef->data))
+		m_buf(reinterpret_cast<uint8_t*>(bufRef->data)),
+		m_length(static_cast<uint32_t>(bufRef->size))
 	{
 		THROW_HR_IF(E_INVALIDARG, bufRef->size > numeric_limits<uint32_t>::max());
 
@@ -44,8 +44,8 @@ namespace winrt::FFmpegInterop::implementation
 	}
 
 	FFmpegInteropBuffer::FFmpegInteropBuffer(_In_ AVPacket_ptr packet) :
-		m_length(packet->size),
-		m_buf(packet->data)
+		m_buf(packet->data),
+		m_length(packet->size)
 	{
 		if (packet->buf != nullptr)
 		{
@@ -61,8 +61,8 @@ namespace winrt::FFmpegInterop::implementation
 	}
 
 	FFmpegInteropBuffer::FFmpegInteropBuffer(_In_ AVBlob_ptr buf, _In_ uint32_t bufSize) :
-		m_length(bufSize),
-		m_buf(static_cast<uint8_t*>(buf.get()))
+		m_buf(static_cast<uint8_t*>(buf.get())),
+		m_length(bufSize)
 	{
 		m_buf.get_deleter() = [buf{ move(buf) }](uint8_t*) noexcept { };
 	}
@@ -83,7 +83,7 @@ namespace winrt::FFmpegInterop::implementation
 				}
 			};
 
-		// Call lambda to set p
+		// Call deleter lambda to set p
 		deleter(nullptr);
 
 		m_buf.reset(p);

--- a/FFmpegInterop/FFmpegInteropBuffer.cpp
+++ b/FFmpegInterop/FFmpegInteropBuffer.cpp
@@ -86,7 +86,7 @@ namespace winrt::FFmpegInterop::implementation
 		// Call deleter lambda to set p
 		deleter(nullptr);
 
-		m_buf.reset(p);
+		m_buf.reset(exchange(p, nullptr));
 		m_buf.get_deleter() = move(deleter);
 	}
 

--- a/FFmpegInterop/FFmpegInteropBuffer.cpp
+++ b/FFmpegInterop/FFmpegInteropBuffer.cpp
@@ -24,26 +24,27 @@ using namespace std;
 namespace winrt::FFmpegInterop::implementation
 {
 	FFmpegInteropBuffer::FFmpegInteropBuffer(_In_ AVBufferRef* bufRef) :
-		m_buf(reinterpret_cast<uint8_t*>(bufRef->data)),
 		m_length(static_cast<uint32_t>(bufRef->size))
 	{
 		THROW_HR_IF(E_INVALIDARG, bufRef->size > numeric_limits<uint32_t>::max());
 
 		AVBufferRef_ptr bufRefCopy{ av_buffer_ref(bufRef) };
 		THROW_IF_NULL_ALLOC(bufRefCopy);
+
+		m_buf.reset(bufRef->data);
 		m_buf.get_deleter() = [bufRefCopy{ move(bufRefCopy) }](uint8_t*) noexcept { };
 	}
 
 	FFmpegInteropBuffer::FFmpegInteropBuffer(_In_ AVBufferRef_ptr bufRef) :
-		m_buf(reinterpret_cast<uint8_t*>(bufRef->data)),
 		m_length(static_cast<uint32_t>(bufRef->size))
 	{
 		THROW_HR_IF(E_INVALIDARG, bufRef->size > numeric_limits<uint32_t>::max());
 
+		m_buf.reset(bufRef->data);
 		m_buf.get_deleter() = [bufRef{ move(bufRef) }](uint8_t*) noexcept { };
 	}
 
-	FFmpegInteropBuffer::FFmpegInteropBuffer(_In_ AVPacket_ptr packet) :
+	FFmpegInteropBuffer::FFmpegInteropBuffer(_In_ AVPacket_ptr packet) noexcept :
 		m_buf(packet->data),
 		m_length(packet->size)
 	{
@@ -60,7 +61,7 @@ namespace winrt::FFmpegInterop::implementation
 		}
 	}
 
-	FFmpegInteropBuffer::FFmpegInteropBuffer(_In_ AVBlob_ptr buf, _In_ uint32_t bufSize) :
+	FFmpegInteropBuffer::FFmpegInteropBuffer(_In_ AVBlob_ptr buf, _In_ uint32_t bufSize) noexcept :
 		m_buf(static_cast<uint8_t*>(buf.get())),
 		m_length(bufSize)
 	{

--- a/FFmpegInterop/FFmpegInteropBuffer.cpp
+++ b/FFmpegInterop/FFmpegInteropBuffer.cpp
@@ -29,18 +29,18 @@ namespace winrt::FFmpegInterop::implementation
 	{
 		THROW_HR_IF(E_INVALIDARG, bufRef->size > numeric_limits<uint32_t>::max());
 
-		AVBufferRef* bufRefCopy{ av_buffer_ref(bufRef) };
+		AVBufferRef_ptr bufRefCopy{ av_buffer_ref(bufRef) };
 		THROW_IF_NULL_ALLOC(bufRefCopy);
-		m_buf.get_deleter() = [AVBufferRef_ptr{ bufRefCopy }](uint8_t*) noexcept { };
+		m_buf.get_deleter() = [bufRefCopy{ move(bufRefCopy) }](uint8_t*) noexcept { };
 	}
 
 	FFmpegInteropBuffer::FFmpegInteropBuffer(_In_ AVBufferRef_ptr bufRef) :
 		m_length(static_cast<uint32_t>(bufRef->size)),
-		m_buf(reinterpret_cast<uint8_t*>(bufRef->data), [AVBufferRef_ptr{ bufRef.get() }](uint8_t*) noexcept { })
+		m_buf(reinterpret_cast<uint8_t*>(bufRef->data))
 	{
-		size_t bufRefSize{ bufRef->size };
-		bufRef.release(); // The lambda has taken ownership
-		THROW_HR_IF(E_INVALIDARG, bufRefSize > numeric_limits<uint32_t>::max());
+		THROW_HR_IF(E_INVALIDARG, bufRef->size > numeric_limits<uint32_t>::max());
+
+		m_buf.get_deleter() = [bufRef{ move(bufRef) }](uint8_t*) noexcept { };
 	}
 
 	FFmpegInteropBuffer::FFmpegInteropBuffer(_In_ AVPacket_ptr packet) :
@@ -50,20 +50,21 @@ namespace winrt::FFmpegInterop::implementation
 		if (packet->buf != nullptr)
 		{
 			// Packet is ref counted. Take ownership of its buffer.
-			m_buf.get_deleter() = [AVBufferRef_ptr{ exchange(packet->buf, nullptr) }](uint8_t*) noexcept { };
+			AVBufferRef_ptr bufRef{ exchange(packet->buf, nullptr) };
+			m_buf.get_deleter() = [bufRef{ move(bufRef) }](uint8_t*) noexcept { };
 		}
 		else
 		{
 			// Packet is not ref counted. We need to keep it alive.
-			m_buf.get_deleter() = [AVPacket_ptr{ packet.release() }](uint8_t*) noexcept { };
+			m_buf.get_deleter() = [packet{ move(packet) }](uint8_t*) noexcept { };
 		}
 	}
 
 	FFmpegInteropBuffer::FFmpegInteropBuffer(_In_ AVBlob_ptr buf, _In_ uint32_t bufSize) :
 		m_length(bufSize),
-		m_buf(static_cast<uint8_t*>(buf.get()), [AVBlob_ptr{ buf.get() }](uint8_t*) noexcept { })
+		m_buf(static_cast<uint8_t*>(buf.get()))
 	{
-		buf.release(); // The lambda has taken ownership
+		m_buf.get_deleter() = [buf{ move(buf) }](uint8_t*) noexcept { };
 	}
 
 	FFmpegInteropBuffer::FFmpegInteropBuffer(_In_ vector<uint8_t>&& buf) noexcept :
@@ -72,14 +73,15 @@ namespace winrt::FFmpegInterop::implementation
 		// We need to move capture buf in the deleter lambda before setting m_buf, 
 		// since moving buf invalidates the pointer returned by buf.data().
 		uint8_t* p{ nullptr };
-		function<void(uint8_t*)> deleter = [pp = &p, buf = move(buf)](uint8_t*) mutable noexcept
-		{
-			if (pp != nullptr)
+		move_only_function<void(uint8_t*)> deleter = 
+			[pp = &p, buf{ move(buf) }](uint8_t*) mutable noexcept
 			{
-				*pp = const_cast<uint8_t*>(buf.data());
-				pp = nullptr;
-			}
-		};
+				if (pp != nullptr)
+				{
+					*pp = const_cast<uint8_t*>(buf.data());
+					pp = nullptr;
+				}
+			};
 
 		// Call lambda to set p
 		deleter(nullptr);

--- a/FFmpegInterop/FFmpegInteropBuffer.h
+++ b/FFmpegInterop/FFmpegInteropBuffer.h
@@ -72,7 +72,7 @@ namespace winrt::FFmpegInterop::implementation
 		void InitMarshaler();
 
 		uint32_t m_length{ 0 };
-		std::unique_ptr<uint8_t, std::function<void(uint8_t*)>> m_buf;
+		std::unique_ptr<uint8_t, std::move_only_function<void(uint8_t*)>> m_buf;
 		com_ptr<IMarshal> m_marshaler;
 		std::once_flag m_marshalerInitFlag;
 	};

--- a/FFmpegInterop/FFmpegInteropBuffer.h
+++ b/FFmpegInterop/FFmpegInteropBuffer.h
@@ -30,8 +30,8 @@ namespace winrt::FFmpegInterop::implementation
 	public:
 		FFmpegInteropBuffer(_In_ AVBufferRef* bufRef);
 		FFmpegInteropBuffer(_In_ AVBufferRef_ptr bufRef);
-		FFmpegInteropBuffer(_In_ AVPacket_ptr packet);
-		FFmpegInteropBuffer(_In_ AVBlob_ptr buf, _In_ uint32_t bufSize);
+		FFmpegInteropBuffer(_In_ AVPacket_ptr packet) noexcept;
+		FFmpegInteropBuffer(_In_ AVBlob_ptr buf, _In_ uint32_t bufSize) noexcept;
 		FFmpegInteropBuffer(_In_ std::vector<uint8_t>&& buf) noexcept;
 
 		// IBuffer

--- a/FFmpegInterop/FFmpegInteropBuffer.h
+++ b/FFmpegInterop/FFmpegInteropBuffer.h
@@ -71,8 +71,8 @@ namespace winrt::FFmpegInterop::implementation
 	private:
 		void InitMarshaler();
 
-		uint32_t m_length{ 0 };
 		std::unique_ptr<uint8_t, std::move_only_function<void(uint8_t*)>> m_buf;
+		uint32_t m_length{ 0 };
 		com_ptr<IMarshal> m_marshaler;
 		std::once_flag m_marshalerInitFlag;
 	};


### PR DESCRIPTION
## Why is this change being made?
There is a memory leak due to FFmpegInteropBuffer not properly capturing the smart pointer for its underlying buffer in the unique_ptr deleter lambdas, which causes the underlying buffer to not be deallocated when FFmpegInteropBuffer is destroyed.

## What changed?
Updated FFmpegInteropBuffer to properly move capture the smart pointer for its underlying buffer in the unique_ptr deleter lambdas, so that the underlying buffer is deallocated when FFmpegInteropBuffer is destroyed.

## How was the change tested?
I verified under a debugger that the underlying buffer is now being deallocated when FFmpegInteropBuffer is destroyed and memory usage is stable for Ogg playback in Media Player with in-proc WME.