### PR TITLE
MSFT: 50055829 - FFmpegInteropByteStreamHandler is closing the byte stream on failure preventing source resolver rollover

### DIFF
--- a/FFmpegInterop/FFmpegInteropByteStreamHandler.cpp
+++ b/FFmpegInterop/FFmpegInteropByteStreamHandler.cpp
@@ -94,7 +94,7 @@ namespace winrt::FFmpegInterop::implementation
 	{
 		auto logger{ FFmpegInteropProvider::CreateMediaSource::Start() };
 
-		// Wrap the byte stream in a proxy to prevent it from being closed if we fail to resolve the media source,
+		// Wrap the byte stream in a proxy to prevent it from being closed if we fail to create and initialize the MSS,
 		// so that the source resolver can rollover and attempt other byte stream handlers.
 		auto byteStreamProxy{ make_self<ByteStreamProxy>(byteStream) };
 

--- a/FFmpegInterop/FFmpegInteropByteStreamHandler.h
+++ b/FFmpegInterop/FFmpegInteropByteStreamHandler.h
@@ -55,7 +55,7 @@ namespace winrt::FFmpegInterop::implementation
 		std::map<IMFAsyncResult*, ShutdownWrapper<IMFMediaSource>> m_map;
 	};
 
-	// Byte stream wrapper that prevents the underlying byte stream from being closed until permitted
+	// Byte stream wrapper that prevents the underlying byte stream from being closed unless permitted
 	class ByteStreamProxy :
 		public implements<
 			ByteStreamProxy,

--- a/FFmpegInterop/FFmpegInteropByteStreamHandler.h
+++ b/FFmpegInterop/FFmpegInteropByteStreamHandler.h
@@ -63,7 +63,7 @@ namespace winrt::FFmpegInterop::implementation
 			IMFGetService>
 	{
 	public:
-		ByteStreamProxy(_In_ IMFByteStream* byteStream)
+		ByteStreamProxy(_In_ IMFByteStream* byteStream) noexcept
 		{
 			m_byteStream.copy_from(byteStream);
 		}
@@ -178,8 +178,6 @@ namespace winrt::FFmpegInterop::implementation
 			_In_ REFIID riid,
 			_COM_Outptr_ void** ppv) noexcept
 		{
-			RETURN_HR_IF_NULL(E_POINTER, ppv);
-
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 			if (guidService == MF_WRAPPED_OBJECT)
 			{

--- a/FFmpegInterop/FFmpegInteropByteStreamHandler.h
+++ b/FFmpegInterop/FFmpegInteropByteStreamHandler.h
@@ -59,8 +59,7 @@ namespace winrt::FFmpegInterop::implementation
 	class ByteStreamProxy :
 		public implements<
 			ByteStreamProxy,
-			IMFByteStream,
-			IMFGetService>
+			IMFByteStream>
 	{
 	public:
 		ByteStreamProxy(_In_ IMFByteStream* byteStream) noexcept
@@ -170,22 +169,6 @@ namespace winrt::FFmpegInterop::implementation
 		{
 			RETURN_HR_IF_EXPECTED(S_FALSE, !m_fAllowClosing);
 			return m_byteStream->Close();
-		}
-
-		// IMFGetService
-		IFACEMETHOD(GetService)(
-			_In_ REFGUID guidService,
-			_In_ REFIID riid,
-			_COM_Outptr_ void** ppv) noexcept
-		{
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-			if (guidService == MF_WRAPPED_OBJECT)
-			{
-				return m_byteStream->QueryInterface(riid, ppv);
-			}
-#endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-
-			RETURN_HR(MF_E_UNSUPPORTED_SERVICE);
 		}
 
 	private:

--- a/FFmpegInterop/FFmpegInteropByteStreamHandler.h
+++ b/FFmpegInterop/FFmpegInteropByteStreamHandler.h
@@ -54,6 +54,146 @@ namespace winrt::FFmpegInterop::implementation
 
 		std::map<IMFAsyncResult*, ShutdownWrapper<IMFMediaSource>> m_map;
 	};
+
+	// Byte stream wrapper that prevents the underlying byte stream from being closed until permitted
+	class ByteStreamProxy :
+		public implements<
+			ByteStreamProxy,
+			IMFByteStream,
+			IMFGetService>
+	{
+	public:
+		ByteStreamProxy(_In_ IMFByteStream* byteStream)
+		{
+			m_byteStream.copy_from(byteStream);
+		}
+
+		void AllowClosing(bool fAllowClosing) noexcept
+		{
+			m_fAllowClosing = fAllowClosing;
+		}
+
+		// IMFByteStream
+		IFACEMETHOD(GetCapabilities(_Out_ DWORD* pdwCapabilities)) noexcept
+		{
+			return m_byteStream->GetCapabilities(pdwCapabilities);
+		}
+
+		IFACEMETHOD(GetLength(_Out_ QWORD* pqwLength)) noexcept
+		{
+			return m_byteStream->GetLength(pqwLength);
+		}
+
+		IFACEMETHOD(SetLength(_In_ QWORD qwLength)) noexcept
+		{
+			return m_byteStream->SetLength(qwLength);
+		}
+
+		IFACEMETHOD(GetCurrentPosition(_Out_ QWORD* pqwPosition)) noexcept
+		{
+			return m_byteStream->GetCurrentPosition(pqwPosition);
+		}
+
+		IFACEMETHOD(SetCurrentPosition(_In_ QWORD qwPosition)) noexcept
+		{
+			return m_byteStream->SetCurrentPosition(qwPosition);
+		}
+
+		IFACEMETHOD(IsEndOfStream(_Out_ BOOL* pfEndOfStream)) noexcept
+		{
+			return m_byteStream->IsEndOfStream(pfEndOfStream);
+		}
+
+		IFACEMETHOD(Read(
+			_Out_writes_to_(cb, *pcbRead) BYTE* pb,
+			_In_ ULONG cb,
+			_Out_ ULONG* pcbRead)) noexcept
+		{
+			return m_byteStream->Read(pb, cb, pcbRead);
+		}
+
+		IFACEMETHOD(BeginRead(
+			_Out_writes_(cb) BYTE* pb,
+			_In_ ULONG cb,
+			_In_ IMFAsyncCallback* pCallback,
+			_In_ IUnknown* pUnkState)) noexcept
+		{
+			return m_byteStream->BeginRead(pb, cb, pCallback, pUnkState);
+		}
+
+		IFACEMETHOD(EndRead(
+			_In_ IMFAsyncResult* pResult,
+			_Out_ ULONG* pcbRead)) noexcept
+		{
+			return m_byteStream->EndRead(pResult, pcbRead);
+		}
+
+		IFACEMETHOD(Write(
+			_In_reads_(cb) const BYTE* pb,
+			_In_ ULONG cb,
+			_Out_ ULONG* pcbWritten)) noexcept
+		{
+			return m_byteStream->Write(pb, cb, pcbWritten);
+		}
+
+		IFACEMETHOD(BeginWrite(
+			_In_reads_(cb) const BYTE* pb,
+			_In_ ULONG cb,
+			_In_ IMFAsyncCallback* pCallback,
+			_In_ IUnknown* pUnkState)) noexcept
+		{
+			return m_byteStream->BeginWrite(pb, cb, pCallback, pUnkState);
+		}
+
+		IFACEMETHOD(EndWrite(
+			_In_ IMFAsyncResult* pResult,
+			_Out_ ULONG* pcbWritten)) noexcept
+		{
+			return m_byteStream->EndWrite(pResult, pcbWritten);
+		}
+
+		IFACEMETHOD(Seek(
+			_In_ MFBYTESTREAM_SEEK_ORIGIN seekOrigin,
+			_In_ LONGLONG llSeekOffset,
+			_In_ DWORD dwSeekFlags,
+			_Out_ QWORD* pqwCurrentPosition)) noexcept
+		{
+			return m_byteStream->Seek(seekOrigin, llSeekOffset, dwSeekFlags, pqwCurrentPosition);
+		}
+
+		IFACEMETHOD(Flush()) noexcept
+		{
+			return m_byteStream->Flush();
+		}
+
+		IFACEMETHOD(Close()) noexcept
+		{
+			RETURN_HR_IF_EXPECTED(S_FALSE, !m_fAllowClosing);
+			return m_byteStream->Close();
+		}
+
+		// IMFGetService
+		IFACEMETHOD(GetService)(
+			_In_ REFGUID guidService,
+			_In_ REFIID riid,
+			_COM_Outptr_ void** ppv) noexcept
+		{
+			RETURN_HR_IF_NULL(E_POINTER, ppv);
+
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+			if (guidService == MF_WRAPPED_OBJECT)
+			{
+				return m_byteStream->QueryInterface(riid, ppv);
+			}
+#endif // WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+
+			RETURN_HR(MF_E_UNSUPPORTED_SERVICE);
+		}
+
+	private:
+		com_ptr<IMFByteStream> m_byteStream;
+		bool m_fAllowClosing{ false };
+	};
 }
 
 namespace winrt::FFmpegInterop::factory_implementation


### PR DESCRIPTION
## Why is this change being made?
FFmpegInteropByteStreamHandler is closing the byte stream on failure which prevents the source resolver from rolling over and attempting other byte stream handlers when the MF_RESOLUTION_CONTENT_DOES_NOT_HAVE_TO_MATCH_EXTENSION_OR_MIME_TYPE flag is set for source resolution.

## What changed?
I added ByteStreamProxy which can be used to wrap a byte stream and prevent it from being closed unless permitted. It forwards all IMFByteStream calls to the underlying byte stream.

FFmpegInteropByteStreamHandler::CreateMediaSource() uses ByteStreamProxy to wrap the byte stream provided to FFmpegInteropByteStreamHandler::BeginCreateObject() and prevent it from being closed unless the MSS is successfully created and initialized, after which the byte stream will be allowed to close when the media source shuts down.

## How was the change tested?
With in-proc WME:
- I verified under a debugger that FFmpegInteropByteStreamHandler no longer attempts to close the byte stream on failure during playback of a corrupted video in Media Player.
- I ran the following TAEF tests:
  - te MF.SourceResolver.unittests.dll /name:SourceResolverTests::TestByteStreamHandlersDontCloseByteStreamOnFailure