### PR TITLE
MSFT: 49931784 - Disable FFmpeg logging in release builds

### DIFF
--- a/FFmpegInterop/dllmain.cpp
+++ b/FFmpegInterop/dllmain.cpp
@@ -34,6 +34,7 @@ BOOL WINAPI DllMain(_In_ HINSTANCE hInstance, _In_ DWORD dwReason, _In_opt_ LPVO
 #ifdef _DEBUG
 		// Register custom FFmpeg logging callback
 		av_log_set_callback(&FFmpegInteropLogging::Log);
+		av_log_set_level(AV_LOG_TRACE);
 #else
 		// Disable FFmpeg logging
 		av_log_set_callback(nullptr);

--- a/FFmpegInterop/dllmain.cpp
+++ b/FFmpegInterop/dllmain.cpp
@@ -31,11 +31,23 @@ BOOL WINAPI DllMain(_In_ HINSTANCE hInstance, _In_ DWORD dwReason, _In_opt_ LPVO
 		// Register TraceLogging provider
 		TraceLoggingRegister(g_FFmpegInteropProvider);
 
-		// Register FFmpegInteropLogging callback
+#ifdef _DEBUG
+		// Register custom FFmpeg logging callback
 		av_log_set_callback(&FFmpegInteropLogging::Log);
+#else
+		// Disable FFmpeg logging
+		av_log_set_callback(nullptr);
+		av_log_set_level(AV_LOG_QUIET);
+#endif // _DEBUG
 	}
 	else if (dwReason == DLL_PROCESS_DETACH)
 	{
+#ifdef _DEBUG
+		// Restore the default FFmpeg logging callback
+		// This is not thread safe! This could leave log_callback in av_vlog() dangling after this DLL is unloaded.
+		av_log_set_callback(av_log_default_callback);
+#endif // _DEBUG
+
 		// Unregister TraceLogging provider
 		TraceLoggingUnregister(g_FFmpegInteropProvider);
 	}


### PR DESCRIPTION
## Why is this change being made?
FFmpegInterop.dll registers a custom FFmpeg logging callback, FmpegInteropLogging::Log(), on DLL load. However, this is not safe to do in scenarios that have multiple DLLs using FFmpeg due to the following race condition:
- FFmpegInterop.dll is loaded and registers its custom FFmpeg logging callback, FmpegInteropLogging::Log().
- OtherModule.dll, which also uses FFmpeg, is also loaded in the same process.
- FFmpegInterop.dll is unloaded and [av_log_callback](https://github.com/search?q=repo%3AFFmpeg%2FFFmpeg+av_log_callback&type=code) becomes a dangling pointer.
- OtherModule.dll is still loaded and using FFmpeg. FFmpeg attempts to invoke the now invalid logging callback, resulting in undefined behavior.

Even if the default logging callback was restored on DLL unload, since there is no thread safety in the FFmpeg logging facility, [log_callback in av_vlog()](https://github.com/search?q=repo%3AFFmpeg%2FFFmpeg+log_callback+symbol%3Aav_vlog&type=code) could become a dangling pointer.

## What changed?
Disabled FFmpeg logging in release builds. Debug builds still register the custom logging callback on DLL load, but now also restore the default logging callback on DLL unload (which isn't thread safe and could still result in a crash).

## How was the change tested?
For Ogg playback in Media Player with in-proc WME, I verified under a debugger that:
- For release builds:
  - FFmpeg logging is disabled during DLL load.
- For debug builds:
  - The custom logging callback is registered/unregistered during DLL load/unload.
  - FFmpeg logging is present in ETW traces collected with WPR.