### PR TITLE
MSFT: 50159985 - UncompressedVideoSampleProvider is not marking keyframes

### DIFF
--- a/FFmpegInterop/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.cpp
@@ -182,6 +182,11 @@ namespace winrt::FFmpegInterop::implementation
 	{
 		vector<pair<GUID, Windows::Foundation::IInspectable>> properties;
 
+		if ((frame->flags & AV_FRAME_FLAG_KEY) != 0)
+		{
+			properties.emplace_back(MFSampleExtension_CleanPoint, PropertyValue::CreateUInt32(true));
+		}
+
 		if ((frame->flags & AV_FRAME_FLAG_INTERLACED) != 0)
 		{
 			properties.emplace_back(MFSampleExtension_Interlaced, PropertyValue::CreateUInt32(true));


### PR DESCRIPTION
## Why is this change being made?
When the MF quality manager enables drop mode on a video stream, the MF stream begins dropping non-keyframes. UncompressedVideoSampleProvider is not marking any samples as keyframes, which results in the MF stream repeatedly requesting and dropping samples until EOS. This manifests as choppy, then frozen video playback. The video stream hogs the CPU during this time which can impact audio playback as well.

## What changed?
I updated UncompressedVideoSampleProvider to mark keyframes by setting MFSampleExtension_CleanPoint on the media sample.

## How was the change tested?
During playback of an Ogg file with Theora video in Media Player with in-proc WME, I artificially enabled drop mode on the MF stream under a debugger, and verified that the displayed video frame is periodically updated on keyframes.