### PR TITLE
MSFT: 21032904 - Fix C4018 (signed/unsigned mismatch) warning in to_cotaskmem_string()

### DIFF
--- a/FFmpegInterop/Utility.h
+++ b/FFmpegInterop/Utility.h
@@ -65,7 +65,8 @@ namespace winrt::FFmpegInterop::implementation
 	{
 		const std::string_view strView{ str };
 		const size_t originalSizeInBytes{ strView.size() * sizeof(char) };
-		THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW), originalSizeInBytes > std::numeric_limits<int32_t>::max());
+		THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW),
+			originalSizeInBytes > static_cast<size_t>(std::numeric_limits<int32_t>::max()));
 
 		// Get the required buffer size
 		int size{ MultiByteToWideChar(CP_UTF8, 0, strView.data(), static_cast<int32_t>(originalSizeInBytes), nullptr, 0) };


### PR DESCRIPTION
## Why is this change being made?
There's an x86 build break from #315 due to a C4018 (signed/unsigned mismatch) warning in to_cotaskmem_string().

## What changed?
Fixed the warning by casting the int32_t to size_t.

## How was the change tested?
Verified x86 build is successful. 