### PR TITLE
MSFT: 50915398 - Add support for custom FFmpeg binary names

### DIFF
--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -87,7 +87,7 @@ common_settings=" \
     --enable-shared \
     --enable-cross-compile \
     --extra-cflags=\"-GUARD:CF -Gy -Gw\" \
-    --extra-ldflags=\"-PROFILE -GUARD:CF -DYNAMICBASE -LTCG -OPT:ICF -OPT:REF\" \
+    --extra-ldflags=\"-PROFILE -GUARD:CF -DYNAMICBASE -OPT:ICF -OPT:REF\" \
     "
 
 # Architecture-specific settings

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -175,7 +175,7 @@
   </ItemGroup>
   <!--
     We use wildcards to support customizing the FFmpeg binary names, however, wildcards are not supported in project
-    items for .vcxproj files. To workaround this limitation, wildcard items are moved to a target body.
+    items for .vcxproj files. To workaround this limitation wildcard items are moved to a target body.
     https://learn.microsoft.com/en-us/cpp/build/reference/vcxproj-files-and-wildcards#move-wildcard-items-to-a-target-body
   -->
   <Target Name="AddWildcardItems" AfterTargets="BuildGenerateSources">

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -156,23 +156,33 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avcodec-61_ms.dll">
+    <_WildcardNone Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avcodec*.dll">
       <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avformat-61_ms.dll">
+    </_WildcardNone>
+    <_WildcardNone Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avformat*.dll">
       <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avutil-59_ms.dll">
+    </_WildcardNone>
+    <_WildcardNone Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avutil*.dll">
       <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\swresample-5_ms.dll">
+    </_WildcardNone>
+    <_WildcardNone Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\swresample*.dll">
       <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\swscale-8_ms.dll">
+    </_WildcardNone>
+    <_WildcardNone Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\swscale*.dll">
       <DeploymentContent>true</DeploymentContent>
-    </None>
+    </_WildcardNone>
     <None Include="packages.config" />
   </ItemGroup>
+  <!--
+    We use wildcards to support customizing the FFmpeg binary names, however, wildcards are not supported in project
+    items for .vcxproj files. To workaround this limitation, wildcard items are moved to a target body.
+    https://learn.microsoft.com/en-us/cpp/build/reference/vcxproj-files-and-wildcards#move-wildcard-items-to-a-target-body
+  -->
+  <Target Name="AddWildcardItems" AfterTargets="BuildGenerateSources">
+    <ItemGroup>
+      <None Include="@(_WildcardNone)" />
+    </ItemGroup>
+  </Target>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" />

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj.filters
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj.filters
@@ -52,11 +52,6 @@
     <AppxManifest Include="Package.appxmanifest" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avcodec-58_ms.dll" />
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avformat-58_ms.dll" />
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avutil-56_ms.dll" />
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\swresample-3_ms.dll" />
-    <None Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\swscale-5_ms.dll" />
     <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/Samples/MediaPlayerCS/MediaPlayerCS.csproj
+++ b/Samples/MediaPlayerCS/MediaPlayerCS.csproj
@@ -134,7 +134,11 @@
     <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Assets\StoreLogo.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
-    <Content Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\*.dll" />
+    <Content Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avcodec*.dll" />
+    <Content Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avformat*.dll" />
+    <Content Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\avutil*.dll" />
+    <Content Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\swresample*.dll" />
+    <Content Include="..\..\ffmpeg\Build\$(PlatformTarget)\bin\swscale*.dll" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">

--- a/Tests/UnitTest.csproj
+++ b/Tests/UnitTest.csproj
@@ -145,7 +145,11 @@
     <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Assets\StoreLogo.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
-    <Content Include="..\ffmpeg\Build\$(PlatformTarget)\bin\*.dll" />
+    <Content Include="..\ffmpeg\Build\$(PlatformTarget)\bin\avcodec*.dll" />
+    <Content Include="..\ffmpeg\Build\$(PlatformTarget)\bin\avformat*.dll" />
+    <Content Include="..\ffmpeg\Build\$(PlatformTarget)\bin\avutil*.dll" />
+    <Content Include="..\ffmpeg\Build\$(PlatformTarget)\bin\swresample*.dll" />
+    <Content Include="..\ffmpeg\Build\$(PlatformTarget)\bin\swscale*.dll" />
     <Content Include="TestFiles\test.txt" />
     <Content Include="TestFiles\silence with album art.mp3" />
   </ItemGroup>


### PR DESCRIPTION
## Why is this change being made?
WME uses custom names for its FFmpeg binaries to differentiate them in telemetry. We need to support both the default FFmpeg binary names and WME's custom FFmpeg binary names in the Media Player sample projects.

## What changed?
- Updated the Media Player sample projects to support both default and custom FFmpeg binary names
  - We use wildcards to support customizing the FFmpeg binary names, however, wildcards are not supported in project items for .vcxproj files. To workaround this limitation wildcard items are moved to a target body. See [.vcxproj files and wildcards | Microsoft Learn](https://learn.microsoft.com/en-us/cpp/build/reference/vcxproj-files-and-wildcards#move-wildcard-items-to-a-target-body) for more info.
- Removed the /LTCG linker option for FFmpeg builds since it had no effect

## How was the change tested?
I built the FFmpeg binaries with the default names and WME's custom names and verified that Ogg playback in the Media Player samples works successfully in both cases.