### PR TITLE
MSFT: 49941670 - Enable Spectre mitigations and CET Shadow Stack

### DIFF
--- a/BuildFFmpeg.ps1
+++ b/BuildFFmpeg.ps1
@@ -114,9 +114,10 @@ Import-Module "$($vsInstance.InstallationPath)\Common7\Tools\Microsoft.VisualStu
 $hostArch = [System.Environment]::Is64BitOperatingSystem ? 'x64' : 'x86'
 $debugLevel = 'None' # Set to Trace for verbose output
 
-# FFmpegConfig.sh sets the /QSpectre option for --extra-cflags to enable Spectre mitigations. However, --extra-cflags
-# options also get passed to the ARM assembler and -QSpectre causes an A2029 (unknown command-line argument) error.
-# To work around this we modify FFmpeg's configure script to have armasm_flags() filter /Q options.
+# FFmpegConfig.sh sets the -QSpectre option for --extra-cflags to enable Spectre mitigations for the FFmpeg binaries.
+# However, --extra-cflags options also get passed to the ARM assembler and -QSpectre causes an A2029 (unknown
+# command-line argument) error for ARM/ARM64 builds. To work around this, we modify FFmpeg's configure script to have
+# armasm_flags() filter out -Q* options.
 $configurePath = "$PSScriptRoot\ffmpeg\configure"
 $configure = Get-Content $configurePath -Encoding UTF8 -Raw
 if (-not ($configure -match '(?sm)armasm_flags\(\).*?^}'))

--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -86,7 +86,7 @@ common_settings=" \
     --disable-dxva2 \
     --enable-shared \
     --enable-cross-compile \
-    --extra-cflags=\"-GUARD:CF -Gy -Gw\" \
+    --extra-cflags=\"-GUARD:CF -Qspectre -Gy -Gw\" \
     --extra-ldflags=\"-PROFILE -GUARD:CF -DYNAMICBASE -OPT:ICF -OPT:REF\" \
     "
 
@@ -97,11 +97,13 @@ if [ -z $arch ]; then
 elif [ $arch == "x86" ]; then
     arch_settings="
         --arch=x86 \
+        --extra-ldflags=\"-CETCOMPAT\" \
         --prefix=../../Build/$arch \
         "
 elif [ $arch == "x64" ]; then
     arch_settings="
         --arch=x86_64 \
+        --extra-ldflags=\"-CETCOMPAT\" \
         --prefix=../../Build/$arch \
         "
 elif [ $arch == "arm" ]; then

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -100,6 +100,7 @@
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
+      <SpectreMitigation>Spectre</SpectreMitigation>
       <Optimization>MinSpace</Optimization>
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -108,6 +109,7 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>/GUARD:CF %(AdditionalOptions)</AdditionalOptions>
+      <CETCompat Condition="'$(Platform)'=='x86' or '$(Platform)'=='x64'">true</CETCompat>
       <Profile>true</Profile>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>


### PR DESCRIPTION
## Why is this change being made?
In-proc WME binaries have the following BinSkim errors:
- [BA2024.EnableSpectreMitigations](https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-ba2024enablespectremitigations)
- [BA2025.EnableShadowStack](https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2025EnableShadowStack)

## What changed?
- Addressed BA2024.EnableSpectreMitigations errors by setting the [/Qspectre](https://learn.microsoft.com/en-us/cpp/build/reference/qspectre) compiler option and linking against the Spectre-mitigated runtime libraries
  - vcvars.bat currently uses the wrong path for OneCore Spectre-mitigated libraries. I filed [vcvars.bat uses the wrong path for OneCore Spectre-mitigated libraries - Developer Community (visualstudio.com)](https://developercommunity.visualstudio.com/t/vcvarsbat-uses-the-wrong-path-for-OneCo/10664642) and added a workaround in BuildFFmpeg.ps1.
  - FFmpegConfig.sh sets the -QSpectre option for --extra-cflags to enable Spectre mitigations for the FFmpeg binaries. However, [--extra-cflags options also get passed to the ARM assembler](https://github.com/search?q=repo%3AFFmpeg%2FFFmpeg+%22add_asflags+%24extra_cflags%22&type=code) and -QSpectre causes an A2029 (unknown command-line argument) error for ARM/ARM64 builds. To work around this, I updated BuildFFmpeg.ps1 to modify FFmpeg's configure script to have [armasm_flags()](https://github.com/search?q=repo%3AFFmpeg%2FFFmpeg+def%3Aarmasm_flags&type=code) filter out -Q* options.
- Addressed BA2025.EnableShadowStack errors by setting the [/CETCOMPAT](https://learn.microsoft.com/en-us/cpp/build/reference/cetcompat) linker option (only applicable to x86 and x64)
- Updated BuildFFmpeg.ps1 to restore the original environment state after the FFmpeg build to address issues with building FFmpeg for different architectures in the same PowerShell instance

## How was the change tested?
- I ran BinSkim on the FFmpegInterop/FFmpeg binaries and verified that no BA2024.EnableSpectreMitigations or BA2025.EnableShadowStack errors are reported.
  - The FFmpeg binaries still have [BA2007.EnableCriticalCompilerWarnings](https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-ba2007enablecriticalcompilerwarnings) errors, but I consider those to be external/by design as FFmpeg's configure script [explicitly disables some warnings when compiling with MSVC](https://github.com/search?q=repo%3AFFmpeg%2FFFmpeg%20def%3Amsvc_flags&type=code).
- I validated the following scenarios:
  - Ogg playback in MediaPlayerCPP
  - Ogg playback in Media Player with in-proc WME