### PR TITLE
MSFT 49941670: Fix Spectre mitigations for FFmpegInterop.dll

### DIFF
--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -66,6 +66,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <LinkIncremental>false</LinkIncremental>
+    <SpectreMitigation>Spectre</SpectreMitigation>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemDefinitionGroup>
@@ -100,7 +101,6 @@
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <SpectreMitigation>Spectre</SpectreMitigation>
       <Optimization>MinSpace</Optimization>
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <FunctionLevelLinking>true</FunctionLevelLinking>


### PR DESCRIPTION
## Why is this change being made?
FFmpegInterop.dll still has a [BA2024.EnableSpectreMitigations](https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-ba2024enablespectremitigations) BinSkim error after #318, because the SpectreMitigation build property needs to be set before Microsoft.Cpp.props is imported so that the Spectre-mitigated runtime libraries are added to the LIBPATH instead of the default runtime libraries.

## What changed?
Set the SpectreMitigation build property before Microsoft.Cpp.props is imported.

## How was the change tested?
- I ran BinSkim on FFmpegInterop.dll and verified that no errors are reported.
- I validated the following scenarios:
  - Ogg playback in MediaPlayerCPP
  - Ogg playback in Media Player with in-proc WME