### PR TITLE
MSFT: 49941670 - Fix UWP build break due to SpectreMitigation build property

### DIFF
--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -66,7 +66,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <LinkIncremental>false</LinkIncremental>
-    <SpectreMitigation>Spectre</SpectreMitigation>
+    <SpectreMitigation Condition="'$(VC_Target_Library_Platform)' == 'Desktop' or '$(VC_Target_Library_Platform)' == 'OneCore'">Spectre</SpectreMitigation>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemDefinitionGroup>


### PR DESCRIPTION
## Why is this change being made?
The out-of-proc WME build (VC_Target_Library_Platform=Store) is broken after #319 added SpectreMitigation=Spectre due to `LNK1104: cannot open file 'msvcprt.lib'`.

[/Qspectre | Microsoft Learn](https://learn.microsoft.com/en-us/cpp/build/reference/qspectre?view=msvc-170)
> There are no versions of Spectre-mitigated libraries for Universal Windows (UWP) apps or components.

## What changed?
Only set SpectreMitigation=Spectre when VC_Target_Library_Platform=Desktop or VC_Target_Library_Platform=OneCore.

## How was the change tested?
- I verified that both the in-proc WME (VC_Target_Library_Platform=OneCore) and out-of-proc WME (VC_Target_Library_Platform=Store) builds are successful, and no [BA2024.EnableSpectreMitigations](https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-ba2024enablespectremitigations) BinSkim errors are reported for either package's binaries.
- I validated the following scenarios:
  - Ogg playback in MediaPlayerCPP
  - Ogg playback in Media Player with in-proc WME and out-of-proc WME