### PR TITLE
MSFT: 21032904 - Fix the property key type for PKEY_Music_Genre

### DIFF
--- a/FFmpegInterop/Metadata.h
+++ b/FFmpegInterop/Metadata.h
@@ -57,7 +57,7 @@ namespace winrt::FFmpegInterop::implementation
 		{ "encoder_options", { PKEY_Media_EncodingSettings, VT_LPWSTR } },
 		{ "encoder_settings", { PKEY_Media_EncodingSettings, VT_LPWSTR } },
 		{ "filename", { PKEY_OriginalFileName, VT_LPWSTR } },
-		{ "genre", { PKEY_Music_Genre, VT_VECTOR | VT_LPWSTR } },
+		{ "genre", { PKEY_Music_Genre, VT_LPWSTR } },
 		{ "initial_key", { PKEY_Music_InitialKey, VT_LPWSTR } },
 		{ "keywords", { PKEY_Keywords, VT_LPWSTR } },
 		{ "language", { PKEY_Language, VT_LPWSTR } },

--- a/FFmpegInterop/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedAudioSampleProvider.cpp
@@ -63,6 +63,8 @@ namespace winrt::FFmpegInterop::implementation
 		// it would set encoding properties with values for the compressed audio type.
 
 		MediaPropertySet properties{ encProp.Properties() };
+		properties.Insert(MF_MT_COMPRESSED, PropertyValue::CreateUInt32(false));
+
 		if (m_channelLayout.order == AV_CHANNEL_ORDER_NATIVE)
 		{
 			properties.Insert(MF_MT_AUDIO_CHANNEL_MASK, PropertyValue::CreateUInt32(static_cast<uint32_t>(m_channelLayout.u.mask)));

--- a/FFmpegInterop/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.cpp
@@ -79,6 +79,7 @@ namespace winrt::FFmpegInterop::implementation
 
 		MediaPropertySet videoProp{ videoEncProp.Properties() };
 		videoProp.Insert(MF_MT_ALL_SAMPLES_INDEPENDENT, PropertyValue::CreateUInt32(true));
+		videoProp.Insert(MF_MT_COMPRESSED, PropertyValue::CreateUInt32(false));
 		videoProp.Insert(MF_MT_INTERLACE_MODE, PropertyValue::CreateUInt32(MFVideoInterlace_MixedInterlaceOrProgressive));
 	}
 

--- a/FFmpegInterop/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.cpp
@@ -78,6 +78,7 @@ namespace winrt::FFmpegInterop::implementation
 		}
 
 		MediaPropertySet videoProp{ videoEncProp.Properties() };
+		videoProp.Insert(MF_MT_ALL_SAMPLES_INDEPENDENT, PropertyValue::CreateUInt32(true));
 		videoProp.Insert(MF_MT_INTERLACE_MODE, PropertyValue::CreateUInt32(MFVideoInterlace_MixedInterlaceOrProgressive));
 	}
 


### PR DESCRIPTION
## Why is this change being made?
I'm writing some new internal WME tests that found a few minor issues.

## What changed?
- Fix the property key type for PKEY_Music_Genre
- Set [MF_MT_COMPRESSED](https://learn.microsoft.com/en-us/windows/win32/medfound/mf-mt-all-samples-independent-attribute) = true for uncompressed audio/video streams
  - This was supposed to already be set for uncompressed video by VideoEncodingProperties::CreateUncompressed(), however, it was getting overwritten and set to false by SampleProvider::SetEncodingProperties().
- Set [MF_MT_ALL_SAMPLES_INDEPENDENT](https://learn.microsoft.com/en-us/windows/win32/medfound/mf-mt-all-samples-independent-attribute) = false for uncompressed video streams 
  - We don't need to explicitly set this for uncompressed audio streams since it's set by AudioEncodingProperties::CreatePcm().

## How was the change tested?
I verified the new internal WME tests are passing now.