### PR TITLE
MSFT: 50731161 - Enable level 4 warnings

### DIFF
--- a/FFmpegInterop/BitstreamReader.cpp
+++ b/FFmpegInterop/BitstreamReader.cpp
@@ -50,7 +50,7 @@ namespace winrt::FFmpegInterop::implementation
 		auto [numBytesToSkip, numBitsToSkip] = div(numBits, BITS_PER_BYTE);
 
 		m_byteIndex += numBytesToSkip;
-		m_bitIndex += numBitsToSkip;
+		m_bitIndex += static_cast<uint8_t>(numBitsToSkip);
 		if (m_bitIndex >= BITS_PER_BYTE)
 		{
 			m_byteIndex++;

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -79,6 +79,7 @@
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\ffmpeg\Build\$(PlatformTarget)\include;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <!-- TODO: Check if warning that broke x86 before now repros for x64 too or if some other warning needs to be explicitly enabled -->
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -76,10 +76,9 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /w44388 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\ffmpeg\Build\$(PlatformTarget)\include;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
-      <!-- TODO: Check if warning that broke x86 before now repros for x64 too or if some other warning needs to be explicitly enabled -->
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -79,6 +79,7 @@
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\ffmpeg\Build\$(PlatformTarget)\include;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>

--- a/FFmpegInterop/FFmpegInteropBuffer.cpp
+++ b/FFmpegInterop/FFmpegInteropBuffer.cpp
@@ -101,7 +101,7 @@ namespace winrt::FFmpegInterop::implementation
 		return m_length;
 	}
 
-	void FFmpegInteropBuffer::Length(_In_ uint32_t length)
+	void FFmpegInteropBuffer::Length(_In_ uint32_t /*length*/)
 	{
 		// We have a fixed length
 		THROW_HR(CO_E_NOT_SUPPORTED);

--- a/FFmpegInterop/FFmpegInteropByteStreamHandler.cpp
+++ b/FFmpegInterop/FFmpegInteropByteStreamHandler.cpp
@@ -184,7 +184,7 @@ namespace winrt::FFmpegInterop::implementation
 	}
 	CATCH_RETURN();
 
-	IFACEMETHODIMP FFmpegInteropByteStreamHandler::GetMaxNumberOfBytesRequiredForResolution(_Out_ QWORD* pcb) noexcept
+	IFACEMETHODIMP FFmpegInteropByteStreamHandler::GetMaxNumberOfBytesRequiredForResolution(_Out_ QWORD* /*pcb*/) noexcept
 	try
 	{
 		RETURN_HR(E_NOTIMPL);

--- a/FFmpegInterop/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/FFmpegInteropMSS.cpp
@@ -498,6 +498,8 @@ namespace winrt::FFmpegInterop::implementation
 	{
 		auto logger{ FFmpegInteropProvider::OnClosed::Start() };
 
+		FFMPEG_INTEROP_TRACE("MediaStreamSourceClosedReason: %d", args.Request().Reason());
+
 		lock_guard<mutex> lock{ m_lock };
 
 		// Unregister event handlers

--- a/FFmpegInterop/Metadata.cpp
+++ b/FFmpegInterop/Metadata.cpp
@@ -53,7 +53,7 @@ namespace winrt::FFmpegInterop::implementation
 #endif // DBG
 
 		const AVDictionaryEntry* tag{ nullptr };
-		while(tag = av_dict_iterate(metadata, tag))
+		while((tag = av_dict_iterate(metadata, tag)) != nullptr)
 		{
 			FFMPEG_INTEROP_TRACE("Property: Key = %hs, Value = %hs", tag->key, tag->value);
 

--- a/FFmpegInterop/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedAudioSampleProvider.cpp
@@ -57,7 +57,7 @@ namespace winrt::FFmpegInterop::implementation
 		THROW_HR_IF_FFMPEG_FAILED(swr_init(m_swrContext.get()));
 	}
 
-	void UncompressedAudioSampleProvider::SetEncodingProperties(_Inout_ const IMediaEncodingProperties& encProp, _In_ bool setFormatUserData)
+	void UncompressedAudioSampleProvider::SetEncodingProperties(_Inout_ const IMediaEncodingProperties& encProp, _In_ bool /*setFormatUserData*/)
 	{
 		// We intentionally don't call SampleProvider::SetEncodingProperties() here as
 		// it would set encoding properties with values for the compressed audio type.

--- a/FFmpegInterop/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.cpp
@@ -144,7 +144,7 @@ namespace winrt::FFmpegInterop::implementation
 			uint8_t* data[4]{ };
 			const int requiredBufferSize{ av_image_fill_pointers(data, AV_PIX_FMT_NV12, frame->height, bufferRef->data, m_lineSizes) };
 			THROW_HR_IF_FFMPEG_FAILED(requiredBufferSize);
-			THROW_HR_IF(MF_E_UNEXPECTED, requiredBufferSize != bufferRef->size);
+			THROW_HR_IF(MF_E_UNEXPECTED, static_cast<size_t>(requiredBufferSize) != bufferRef->size);
 
 			THROW_HR_IF_FFMPEG_FAILED(sws_scale(m_swsContext.get(), frame->data, frame->linesize, 0, frame->height, data, m_lineSizes));
 

--- a/FFmpegInterop/Utility.h
+++ b/FFmpegInterop/Utility.h
@@ -56,7 +56,11 @@ namespace winrt::FFmpegInterop::implementation
 {
 	inline std::string tolower(_Inout_ std::string str)
 	{
-		std::transform(str.begin(), str.end(), str.begin(), [](_In_ char c){ return static_cast<char>(std::tolower(c)); });
+		std::transform(str.begin(), str.end(), str.begin(),
+			[](_In_ unsigned char c)
+			{
+				return static_cast<unsigned char>(std::tolower(c));
+			});
 		return str;
 	}
 

--- a/FFmpegInterop/Utility.h
+++ b/FFmpegInterop/Utility.h
@@ -130,7 +130,9 @@ namespace winrt::FFmpegInterop::implementation
 		const int __status = verify_averror(status); \
 		if (__status < 0) \
 		{ \
+			__pragma(warning(disable:4456)) \
 		 	char buf[AV_ERROR_MAX_STRING_SIZE]{0}; \
+			__pragma(warning(default:4456)) \
 			FFMPEG_INTEROP_TRACE("FFmpeg failed: %hs", av_make_error_string(buf, AV_ERROR_MAX_STRING_SIZE, __status)); \
 			THROW_HR_MSG(averror_to_hresult(__status), #status); \
 		} \
@@ -211,7 +213,7 @@ namespace winrt::FFmpegInterop::implementation
 		ShutdownWrapper(_In_ const ShutdownWrapper& other) = delete;
 		ShutdownWrapper(_In_ ShutdownWrapper&& other) = default;
 
-		ShutdownWrapper(_In_opt_ std::nullptr_t ptr = nullptr) noexcept { }
+		ShutdownWrapper(_In_opt_ std::nullptr_t /*ptr*/ = nullptr) noexcept { }
 
 		ShutdownWrapper(_In_opt_ T* ptr) noexcept :
 			m_ptr(ptr)

--- a/FFmpegInterop/Utility.h
+++ b/FFmpegInterop/Utility.h
@@ -56,7 +56,7 @@ namespace winrt::FFmpegInterop::implementation
 {
 	inline std::string tolower(_Inout_ std::string str)
 	{
-		std::transform(str.begin(), str.end(), str.begin(), [](_In_ char c){ return std::tolower(c); });
+		std::transform(str.begin(), str.end(), str.begin(), [](_In_ char c){ return static_cast<char>(std::tolower(c)); });
 		return str;
 	}
 

--- a/FFmpegInterop/VFWSampleProvider.cpp
+++ b/FFmpegInterop/VFWSampleProvider.cpp
@@ -33,7 +33,7 @@ namespace winrt::FFmpegInterop::implementation
 		
 	}
 
-	void VFWSampleProvider::SetEncodingProperties(_Inout_ const IMediaEncodingProperties& encProp, _In_ bool setFormatUserData)
+	void VFWSampleProvider::SetEncodingProperties(_Inout_ [[maybe_unused]] const IMediaEncodingProperties& encProp, _In_ bool /*setFormatUserData*/)
 	{
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 		// We intentionally don't call SampleProvider::SetEncodingProperties() here. We'll set all of the encoding properties we need.

--- a/FFmpegInterop/dllmain.cpp
+++ b/FFmpegInterop/dllmain.cpp
@@ -21,7 +21,7 @@
 
 using namespace winrt::FFmpegInterop::implementation;
 
-BOOL WINAPI DllMain(_In_ HINSTANCE hInstance, _In_ DWORD dwReason, _In_opt_ LPVOID lpReserved)
+BOOL WINAPI DllMain(_In_ HINSTANCE hInstance, _In_ DWORD dwReason, _In_opt_ LPVOID /*lpReserved*/)
 {
 	if (dwReason == DLL_PROCESS_ATTACH)
 	{

--- a/FFmpegInterop/pch.h
+++ b/FFmpegInterop/pch.h
@@ -72,6 +72,7 @@ typedef struct _MT_CUSTOM_VIDEO_PRIMARIES {
 #endif // !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_GAMES)
 
 // FFmpeg
+#pragma warning(disable: 4244)
 extern "C"
 {
 #include <libavcodec/avcodec.h>
@@ -82,6 +83,7 @@ extern "C"
 #include <libswresample/swresample.h>
 #include <libswscale/swscale.h>
 }
+#pragma warning(default: 4244)
 
 // STL
 #include <algorithm>

--- a/FFmpegInterop/pch.h
+++ b/FFmpegInterop/pch.h
@@ -72,7 +72,7 @@ typedef struct _MT_CUSTOM_VIDEO_PRIMARIES {
 #endif // !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_GAMES)
 
 // FFmpeg
-#pragma warning(disable: 4244)
+#pragma warning(disable:4244)
 extern "C"
 {
 #include <libavcodec/avcodec.h>
@@ -83,7 +83,7 @@ extern "C"
 #include <libswresample/swresample.h>
 #include <libswscale/swscale.h>
 }
-#pragma warning(default: 4244)
+#pragma warning(default:4244)
 
 // STL
 #include <algorithm>


### PR DESCRIPTION
## Why is this change being made?
I've been bitten twice by build breaks due to [C4018 (signed/unsigned mismatch)](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4018?view=msvc-170) warnings that repro'd for x86 but not x64 (#308 and #316). It turns out that for the x64 build the warnings being generated were [C4388 (signed/unsigned mismatch)](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4388?view=msvc-170) which is a level 4, off by default warning.

We want to follow [best practices](https://learn.microsoft.com/en-us/cpp/code-quality/build-reliable-secure-programs?view=msvc-170#23-code-based-or-static-analysis) and enable level 4 warnings.

## What changed?
- Enabled level 4 warnings (`/W4`)
- Enabled [C4388 (signed/unsigned mismatch)](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4388?view=msvc-170), which is a level 4 warning but off by default (`/w44388`)
- Addressed build breaks due to newly enabled warnings being treated as errors

## How was the change tested?
I validated the following scenarios:
- Ogg playback in MediaPlayerCPP/MediaPlayerCS
- Ogg playback in Media Player with WME (in-proc and out-of-proc)
- MKV with Vorbis/Theora playback in Media Player with WME (in-proc and out-of-proc)