### PR TITLE
MSFT: 55143016 - Propagate the HRESULT for file stream read/seek failures

### DIFF
--- a/FFmpegInterop/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/FFmpegInteropMSS.cpp
@@ -39,16 +39,10 @@ namespace
 		IStream* fileStream{ reinterpret_cast<IStream*>(ptr) };
 		ULONG bytesRead{ 0 };
 
-		if (FAILED(fileStream->Read(buf, bufSize, &bytesRead)))
-		{
-			return AVERROR_EXTERNAL;
-		}
+		RETURN_IF_FAILED(fileStream->Read(buf, bufSize, &bytesRead));
 
 		// Assume we've reached EOF if we didn't read any bytes
-		if (bytesRead == 0)
-		{
-			return AVERROR_EOF;
-		}
+		RETURN_HR_IF(static_cast<HRESULT>(AVERROR_EOF), bytesRead == 0);
 
 		return bytesRead;
 	}
@@ -61,10 +55,7 @@ namespace
 		in.QuadPart = pos;
 		ULARGE_INTEGER out{ 0 };
 
-		if (FAILED(fileStream->Seek(in, whence, &out)))
-		{
-			return AVERROR_EXTERNAL;
-		}
+		RETURN_IF_FAILED(fileStream->Seek(in, whence, &out));
 
 		return out.QuadPart;
 	}
@@ -75,6 +66,7 @@ namespace winrt::FFmpegInterop::implementation
 	void FFmpegInteropMSS::InitializeFromStream(_In_ const IRandomAccessStream& fileStream, _In_ const MediaStreamSource& mss, _In_opt_ const FFmpegInterop::FFmpegInteropMSSConfig& config)
 	{
 		auto logger{ FFmpegInteropProvider::InitializeFromStream::Start() };
+		[[maybe_unused]] wil::ThreadErrorContext errorContext; // Enable WIL's thread error cache for averror_to_hresult()
 
 		(void) make<FFmpegInteropMSS>(fileStream, mss, config);
 
@@ -84,6 +76,7 @@ namespace winrt::FFmpegInterop::implementation
 	void FFmpegInteropMSS::InitializeFromUri(_In_ const hstring& uri, _In_ const MediaStreamSource& mss, _In_opt_ const FFmpegInterop::FFmpegInteropMSSConfig& config)
 	{
 		auto logger{ FFmpegInteropProvider::InitializeFromUri::Start() };
+		[[maybe_unused]] wil::ThreadErrorContext errorContext; // Enable WIL's thread error cache for averror_to_hresult()
 
 		(void) make<FFmpegInteropMSS>(uri, mss, config);
 
@@ -374,6 +367,7 @@ namespace winrt::FFmpegInterop::implementation
 	void FFmpegInteropMSS::OnStarting(_In_ const MediaStreamSource&, _In_ const MediaStreamSourceStartingEventArgs& args)
 	{
 		auto logger{ FFmpegInteropProvider::OnStarting::Start() };
+		[[maybe_unused]] wil::ThreadErrorContext errorContext; // Enable WIL's thread error cache for averror_to_hresult()
 
 		const MediaStreamSourceStartingRequest request{ args.Request() };
 		const IReference<TimeSpan> startPosition{ request.StartPosition() };
@@ -425,6 +419,7 @@ namespace winrt::FFmpegInterop::implementation
 	void FFmpegInteropMSS::OnSampleRequested(_In_ const MediaStreamSource&, _In_ const MediaStreamSourceSampleRequestedEventArgs& args)
 	{
 		auto logger{ FFmpegInteropProvider::OnSampleRequested::Start() };
+		[[maybe_unused]] wil::ThreadErrorContext errorContext; // Enable WIL's thread error cache for averror_to_hresult()
 
 		const MediaStreamSourceSampleRequest request{ args.Request() };
 

--- a/FFmpegInterop/Utility.h
+++ b/FFmpegInterop/Utility.h
@@ -116,7 +116,16 @@ namespace winrt::FFmpegInterop::implementation
 		case AVERROR_INVALIDDATA:
 			return MF_E_INVALID_FILE_FORMAT;
 		default:
-			return E_FAIL;
+			{
+				wil::FailureInfo info;
+				if (wil::GetLastError(info, 0, status))
+				{
+					// Assume status is an HRESULT if it was traced by WIL
+					return status;
+				}
+
+				return E_FAIL;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Why is this change being made?
When a file stream read/seek fails, FileStreamRead()/FileStreamSeek() currently return AVERROR_EXTERNAL. This propagates up the call stack and gets converted to E_FAIL by averror_to_hresult() since there is no explicit mapping for it.

We want to propagate the failed HRESULT that occurred instead so that we can provide a more specific error/message to the app/user.
 
## What changed?
- I updated FileStreamRead()/FileStreamSeek() to return the failed HRESULT instead of AVERROR_EXTERNAL when a file stream read/seek fails.
- In order to detect that the status returned by FFmpeg is an HRESULT and not an unmapped AVERROR, I updated averror_to_hresult() to assume that the status is an HRESULT if it's in WIL's thread error cache. See [Internals Local data - Thread-local data · microsoft/wil Wiki](https://github.com/microsoft/wil/wiki/Internals-Local-data#thread-local-data) for background info on WIL's thread error cache.
- [will::details_abi::ThreadLocalData::SetLastError()](https://github.com/search?q=repo%3Amicrosoft%2Fwil+setlasterror+path%3Aresult.h&type=code) won't cache information about errors unless there is a listener, so I added a wil::ThreadErrorContext to listen for errors at the start of tracelogging activities that perform a file stream read/seek.

## How was the change tested?
I simulated a file stream read failure under a debugger and verified that the failed HRESULT was propagated up to the app rather than E_FAIL.