### PR TITLE
Add fuzzing flag to FFmpeg build scripts to build FFmpeg with ASAN and SanCov enabled

### DIFF
--- a/BuildFFmpeg.ps1
+++ b/BuildFFmpeg.ps1
@@ -175,7 +175,7 @@ foreach ($arch in $Architectures)
             exit 1
         }
         Write-Host "Adding $fuzzingLibPath to the LIB environment variable"
-        $env:LIB="$env:LIB;$fuzzingLibPath"
+        $env:LIB = "$env:LIB;$fuzzingLibPath"
         $opts += '--fuzzing'
     }
 

--- a/BuildFFmpeg.ps1
+++ b/BuildFFmpeg.ps1
@@ -66,7 +66,7 @@ param(
 
     [string]$Settings = '',
 
-    [bool]$Fuzzing = $false
+    [switch]$Fuzzing
 )
 
 # Validate FFmpeg submodule
@@ -176,7 +176,7 @@ foreach ($arch in $Architectures)
         }
 
         # Copy the contents of $VCInstallToolsDir\lib\arch\* to $PSScriptRoot\libs 
-        Write-Host "Copying fuzzing libs from $env:VCToolsInstallDir to $fuzzingLibsDir"
+        Write-Host "Copying fuzzing libs from $env:VCToolsInstallDir\lib\$arch to $fuzzingLibsDir"
         Copy-Item -Path "$env:VCToolsInstallDir\lib\$arch\*" -Destination $fuzzingLibsDir -Recurse -Force
         
         # FFmpeg build needs forward slashes in paths

--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -162,7 +162,7 @@ rm -rf Output/$arch
 mkdir -p Output/$arch
 cd Output/$arch
 
-eval ../../configure $common_settings $arch_settings $app_platform_settings $crt_settings $onecore_settings $user_settings &&
+eval ../../configure $common_settings $arch_settings $app_platform_settings $crt_settings $onecore_settings $user_settings $fuzz_settings $fuzz_crt_settings &&
 make -j`nproc` &&
 make install
 

--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -152,8 +152,7 @@ if [[ $fuzzing ]]; then
         fuzz_crt_settings="--extra-ldflags=\"-DEFAULTLIB:sancov.lib\""
     else
         fuzz_crt_settings="--extra-ldflags=\"-DEFAULTLIB:libsancov.lib\""
-    fi
-    
+    fi  
 fi
 
 

--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -155,7 +155,6 @@ if [[ $fuzzing ]]; then
     fi  
 fi
 
-
 # Build FFmpeg
 pushd $dir/ffmpeg > /dev/null
 

--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -2,7 +2,7 @@
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 # Parse the options
-options=$(getopt -o "" --long arch:,app-platform:,settings:,crt:,fuzzing-libs: -n "$0" -- "$@")
+options=$(getopt -o "" --long arch:,app-platform:,settings:,crt:,fuzzing -n "$0" -- "$@")
 if [ $? -ne 0 ]; then
     echo "ERROR: Invalid option(s)"
     exit 1
@@ -67,10 +67,9 @@ while true; do
             user_settings=$2
             shift 2
             ;;
-        --fuzzing-libs)
+        --fuzzing)
             fuzzing=true
-            fuzzing_libs=$2
-            shift 2
+            shift
             ;;
         --)
             shift
@@ -142,16 +141,13 @@ if [[ $fuzzing ]]; then
         exit 1
     fi
 
-    fuzz_settings="
-        --extra-cflags=\"-fsanitize=address -fsanitize-coverage=inline-8bit-counters -fsanitize-coverage=edge -fsanitize-coverage=trace-cmp -fsanitize-coverage=trace-div\" \
-        --extra-ldflags=\"-LIBPATH:$fuzzing_libs\" \
-        "
+    fuzz_settings="--extra-cflags=\"-fsanitize=address -fsanitize-coverage=inline-8bit-counters -fsanitize-coverage=edge -fsanitize-coverage=trace-cmp -fsanitize-coverage=trace-div\" "
 
     # Add sancov.lib or libsancov.lib based on CRT
     if [[ $crt == "dynamic" ]]; then
-        fuzz_crt_settings="--extra-ldflags=\"-DEFAULTLIB:sancov.lib\""
+        fuzz_settings+="--extra-ldflags=\"-DEFAULTLIB:sancov.lib\""
     else
-        fuzz_crt_settings="--extra-ldflags=\"-DEFAULTLIB:libsancov.lib\""
+        fuzz_settings+="--extra-ldflags=\"-DEFAULTLIB:libsancov.lib\""
     fi  
 fi
 
@@ -162,7 +158,7 @@ rm -rf Output/$arch
 mkdir -p Output/$arch
 cd Output/$arch
 
-eval ../../configure $common_settings $arch_settings $app_platform_settings $crt_settings $onecore_settings $user_settings $fuzz_settings $fuzz_crt_settings &&
+eval ../../configure $common_settings $arch_settings $app_platform_settings $crt_settings $onecore_settings $user_settings $fuzz_settings &&
 make -j`nproc` &&
 make install
 

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -68,6 +68,9 @@
     <LinkIncremental>false</LinkIncremental>
     <SpectreMitigation Condition="'$(VC_Target_Library_Platform)' == 'Desktop' or '$(VC_Target_Library_Platform)' == 'OneCore'">Spectre</SpectreMitigation>
   </PropertyGroup>
+  <PropertyGroup>
+    <Fuzzing Condition="'$(Fuzzing)' == ''">false</Fuzzing>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemDefinitionGroup>
     <ClCompile>
@@ -114,6 +117,17 @@
       <Profile>true</Profile>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Fuzzing)'=='true'">
+    <ClCompile>
+      <AdditionalOptions>/fsanitize=address /fsanitize-coverage=inline-8bit-counters /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div %(AdditionalOptions)</AdditionalOptions>
+      <DebugInformationFormat Condition="'$(Configuration)'=='Debug'">ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(VCToolsInstallDir)\lib\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies Condition="'$(RuntimeLibrary)'=='MultiThreadedDebug' or '$(RuntimeLibrary)'=='MultiThreaded'">libsancov.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(RuntimeLibrary)'!='MultiThreadedDebug' and '$(RuntimeLibrary)'!='MultiThreaded'">sancov.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/FFmpegInterop/VFWSampleProvider.cpp
+++ b/FFmpegInterop/VFWSampleProvider.cpp
@@ -47,7 +47,7 @@ namespace winrt::FFmpegInterop::implementation
 		bih.biWidth = codecPar->width;
 		bih.biHeight = codecPar->height;
 		bih.biPlanes = 1; // Must be 1
-		bih.biBitCount = codecPar->bits_per_coded_sample;
+		bih.biBitCount = static_cast<WORD>(codecPar->bits_per_coded_sample);
 		bih.biCompression = codecPar->codec_tag;
 
 		copy(codecPar->extradata, codecPar->extradata + codecPar->extradata_size, vihBuf.begin() + sizeof(VIDEOINFOHEADER));


### PR DESCRIPTION
### Why is this change being made?
To create fuzzers for WME (Ogg, Theora, Vorbis), which rely on FFmpeg, we need to be able to build FFmpeg with ASAN and SanCov enabled


### What changed?
To enable fuzzing, we need to add the compiler flags "/fsanitize=address /fsanitize-coverage=inline-8bit-counters /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div" and link to either sancov.lib (dynamic CRT, /MD) or libsancov.lib (static CRT, /MT). The libraries are located in $VCToolsInstallDir\lib\\$arch, which is dependent upon the Visual Studio installation of the building machine. Fuzzing documentation can be found [here](https://eng.ms/docs/cloud-ai-platform/azure-edge-platform-aep/aep-security/epsf-edge-and-platform-security-fundamentals/the-onefuzz-service/onefuzz/faq/notwindows/walkthrough).

I added a fuzzing switch parameter to the PS build script. If fuzzing is enabled, the libs in $VCInstallToolsDir\lib\\$arch get copied over to a different directory. The $VCInstallToolsDir file path has spaces in it, which caused problems while trying to build FFmeg. The new directory with the libraries will be passed in as a parameter to the FFmpeg bash script. The bash script applies the right compiler flags and linker flags to build FFmpeg with ASAN and SanCov enabled if fuzzing is enabled, specifying the library to link based on the CRT used.

I added a fuzzing parameter to the FFmpegInterop.vcxproj file and changed the configuration if that was set to true to include the ASAN compiler flags and link to either sancov.lib or libsancov.lib depending on the RuntimeLibrary. 

ASAN doesn't compile with EditAndContinue (/ZI), so I had to change the DebugInformationFormat to ProgramDatabase (/Zi) for Debug configurations.
There was a level 4 warning in VFWSampleProvider.cpp so I added a static cast to fix that.

### How was the change tested?
Built FFmpeg with x64 and fuzzing flag set to true
Built FFmpegInterop with the following command: MSBuild FFmpegInterop.sln -t:Clean;Build /p:Configuration=Debug /p:Platform=x64 /p:Fuzzing=true