### PR TITLE
Fix directory path for fuzzing libraries

### DIFF
--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -119,7 +119,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-  <Target Name="ShowRuntimeLibrary" BeforeTargets="Build">
+  <Target Name="ShowRuntimeLibrary" AfterTargets="Build">
     <Message Text="RuntimeLibrary: $(RuntimeLibrary)" Importance="high" />
   </Target>
   <ItemDefinitionGroup Condition="'$(Fuzzing)'=='true'">

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -113,7 +113,7 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>/GUARD:CF %(AdditionalOptions)</AdditionalOptions>
-      <CETCompat Condition="'$(Platform)'=='Win32' or '$(Platform)'=='x86' or '$(Platform)'=='x64'">true</CETCompat>
+      <CETCompat Condition="'$(Platform)'=='Win32' or '$(Platform)'=='x64'">true</CETCompat>
       <Profile>true</Profile>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -113,19 +113,22 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>/GUARD:CF %(AdditionalOptions)</AdditionalOptions>
-      <CETCompat Condition="'$(Platform)'=='x86' or '$(Platform)'=='x64'">true</CETCompat>
+      <CETCompat Condition="'$(Platform)'=='Win32' or '$(Platform)'=='x64'">true</CETCompat>
       <Profile>true</Profile>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
+  <Target Name="ShowRuntimeLibrary" BeforeTargets="Build">
+    <Message Text="RuntimeLibrary: $(RuntimeLibrary)" Importance="high" />
+  </Target>
   <ItemDefinitionGroup Condition="'$(Fuzzing)'=='true'">
     <ClCompile>
       <AdditionalOptions>/fsanitize=address /fsanitize-coverage=inline-8bit-counters /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div %(AdditionalOptions)</AdditionalOptions>
       <DebugInformationFormat Condition="'$(Configuration)'=='Debug'">ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(VCToolsInstallDir)\lib\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(VCToolsInstallDir)\lib\$(PlatformTarget);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies Condition="'$(RuntimeLibrary)'=='MultiThreadedDebug' or '$(RuntimeLibrary)'=='MultiThreaded'">libsancov.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(RuntimeLibrary)'!='MultiThreadedDebug' and '$(RuntimeLibrary)'!='MultiThreaded'">sancov.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -113,15 +113,12 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>/GUARD:CF %(AdditionalOptions)</AdditionalOptions>
-      <CETCompat Condition="'$(Platform)'=='Win32' or '$(Platform)'=='x64'">true</CETCompat>
+      <CETCompat Condition="'$(Platform)'=='Win32' or '$(Platform)'=='x86' or '$(Platform)'=='x64'">true</CETCompat>
       <Profile>true</Profile>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-  <Target Name="ShowRuntimeLibrary" AfterTargets="Build">
-    <Message Text="RuntimeLibrary: $(RuntimeLibrary)" Importance="high" />
-  </Target>
   <ItemDefinitionGroup Condition="'$(Fuzzing)'=='true'">
     <ClCompile>
       <AdditionalOptions>/fsanitize=address /fsanitize-coverage=inline-8bit-counters /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div %(AdditionalOptions)</AdditionalOptions>


### PR DESCRIPTION
**Why is this change being made?**
The Platform macro resolved to Win32 in cases I assumed it would be set to x86. This caused the ASAN library include path to be incorrect, and the building FFmpegInterop with fuzzing for x86 to fail.

**What changed?**
Changed the ASAN library include path to use PlatformTarget instead of Platform, which resolves to x86 instead of Win32. The path for the FFmpeg Build libraries also uses PlatformTarget in line 91.
Changed another condition that was checking if Platform equaled x86 to also check if Platform equals Win32, as these are essentially the same condition.

**How was the change tested?**
Built FFmpegInterop for all architectures with and without fuzzing (excluding arm64 for fuzzing) using this branch via the WME pipeline.