### PR TITLE
MSFT: 54032803 - Add support for enabling PREfast and EO-compliant compiler warnings for FFmpeg builds

### DIFF
--- a/BuildFFmpeg.ps1
+++ b/BuildFFmpeg.ps1
@@ -36,12 +36,20 @@ Specifies one or more patches or directories containing patches to apply to FFmp
 .PARAMETER CompilerRsp
 Specifies one or more compiler response files (.rsp) to pass to the FFmpeg build.
 
+See the following resource for more information about compiler response files:
+- https://learn.microsoft.com/en-us/cpp/build/reference/at-specify-a-compiler-response-file
+
 .PARAMETER Prefast
 Specifies one or more rulesets to use for PREfast static analysis.
 
+See the following resource for more information about PREfast static analysis:
+- https://learn.microsoft.com/en-us/cpp/build/reference/analyze-code-analysis
+
 .PARAMETER SarifLogs
 Specifies whether to enable SARIF output diagnostics for MSVC.
-https://learn.microsoft.com/en-us/cpp/build/reference/sarif-output
+
+See the following resource for more information about SARIF diagnostics:
+- https://learn.microsoft.com/en-us/cpp/build/reference/sarif-output
 
 .PARAMETER Fuzzing
 Specifies whether to build FFmpeg with fuzzing support.

--- a/BuildFFmpeg.ps1
+++ b/BuildFFmpeg.ps1
@@ -36,6 +36,10 @@ Specifies one or more patches or directories containing patches to apply to FFmp
 .PARAMETER Prefast
 Specifies one or more rulesets to use for PREfast static analysis.
 
+.PARAMETER SarifLogs
+Specifies whether to enable SARIF output diagnostics for MSVC.
+https://learn.microsoft.com/en-us/cpp/build/reference/sarif-output
+
 .PARAMETER Fuzzing
 Specifies whether to build FFmpeg with fuzzing support.
 
@@ -70,6 +74,7 @@ param(
     [string]$Settings,
     [string]$Patches,
     [string[]]$Prefast,
+    [switch]$SarifLogs,
     [switch]$Fuzzing
 )
 
@@ -241,6 +246,11 @@ foreach ($arch in $Architectures)
         $opts += '--prefast', "$($Prefast -join ';')"
     }
 
+    if ($SarifLogs)
+    {
+        $opts += '--sarif-logs'
+    }
+
     # Fuzzing requires libraries in the $VCToolsInstallDir to be linked
     if ($Fuzzing)
     {
@@ -250,6 +260,7 @@ foreach ($arch in $Architectures)
             Write-Error "ERROR: $fuzzingLibPath does not exist. Ensure the Visual Studio installation is correct."
             exit 1
         }
+
         Write-Host "Adding $fuzzingLibPath to the LIB environment variable"
         $env:LIB = "$env:LIB;$fuzzingLibPath"
         $opts += '--fuzzing'
@@ -273,4 +284,3 @@ foreach ($arch in $Architectures)
         exit 1
     }
 }
-

--- a/BuildFFmpeg.ps1
+++ b/BuildFFmpeg.ps1
@@ -93,7 +93,7 @@ function ApplyFFmpegPatch([string]$path)
     if (Test-Path $path -PathType Container)
     {
         # Apply all patches in the directory
-        $patches = Get-ChildItem -Path $path
+        $patches = Get-ChildItem -Path $path\*.patch
         foreach ($patch in $patches)
         {
             ApplyFFmpegPatch($patch)

--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -175,7 +175,7 @@ if [[ $fuzzing ]]; then
 
     fuzz_settings="\
         --extra-cflags=\"-fsanitize=address -fsanitize-coverage=inline-8bit-counters -fsanitize-coverage=edge \
-        -fsanitize-coverage=trace-cmp -fsanitize-coverage=trace-div\""
+        -fsanitize-coverage=trace-cmp -fsanitize-coverage=trace-div\" "
 
     # Add sancov.lib or libsancov.lib based on CRT
     if [[ $crt == "dynamic" ]]; then

--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -68,27 +68,19 @@ while true; do
             shift 2
             ;;
         --compiler-rsp)
-            # Convert the response file paths from Windows to Unix format
-            IFS=';' read -r -a rsps <<< "$2"
-            for i in "${!rsps[@]}"; do
-                rsps[$i]="@$(cygpath --unix "${rsps[$i]}")"
-            done
-            rsps=$(IFS=' '; echo "${rsps[*]}")
+            # Convert the compiler response file path from Windows to Unix format
+            rsp="$(cygpath --unix "$2")"
 
-            compiler_rsp_settings+="--extra-cflags=\"$rsps\""
+            compiler_rsp_settings+="--extra-cflags=\"@$rsp\""
             shift 2
             ;;
         --prefast)
-            # Convert the ruleset paths from Windows to Unix format
-            IFS=';' read -r -a rulesets <<< "$2"
-            for i in "${!rulesets[@]}"; do
-                rulesets[$i]="$(cygpath --unix "${rulesets[$i]}")"
-            done
-            rulesets=$(IFS=';'; echo "${rulesets[*]}")
+            # Convert the ruleset path from Windows to Unix format
+            ruleset="$(cygpath --unix "$2")"
 
             prefast_settings="\
                 --extra-cflags=\"-analyze -analyze:log:includesuppressed -analyze:log:format:sarif -analyze:plugin \
-                EspXEngine.dll -analyze:ruleset $rulesets\""
+                EspXEngine.dll -analyze:ruleset $ruleset\""
             shift 2
             ;;
         --sarif-logs)

--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -2,7 +2,7 @@
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 # Parse the options
-options=$(getopt -o "" --long arch:,app-platform:,settings:,crt:,prefast:,fuzzing -n "$0" -- "$@")
+options=$(getopt -o "" --long arch:,app-platform:,settings:,crt:,prefast:,sarif-logs,fuzzing -n "$0" -- "$@")
 if [ $? -ne 0 ]; then
     echo "ERROR: Invalid option(s)"
     exit 1
@@ -22,12 +22,12 @@ while true; do
                     app_platform_settings="--extra-cflags=\"-DWINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP\""
                     ;;
                 onecore)
-                    app_platform_settings=" \
+                    app_platform_settings="\
                         --extra-cflags=\"-DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WIN32_WINNT=0x0A00\" \
                         --extra-ldflags=\"-APPCONTAINER WindowsApp.lib -NODEFAULTLIB:kernel32.lib -DEFAULTLIB:onecore.lib\""
                     ;;
                 uwp)
-                    app_platform_settings=" \
+                    app_platform_settings="\
                         --extra-cflags=\"-DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WIN32_WINNT=0x0A00\" \
                         --extra-ldflags=\"-APPCONTAINER WindowsApp.lib\""
                     ;;
@@ -68,8 +68,14 @@ while true; do
             shift 2
             ;;
         --prefast)
-            prefast_rulesets=$2
+            prefast_settings="--extra-cflags=\"\
+                -analyze -analyze:log:includesuppressed -analyze:log:format:sarif -analyze:plugin EspXEngine.dll \
+                -analyze:ruleset $2\""
             shift 2
+            ;;
+        --sarif-logs)
+            sarif_logs=true
+            shift
             ;;
         --fuzzing)
             fuzzing=true
@@ -100,47 +106,46 @@ common_settings=" \
     "
 
 # Architecture-specific settings
-if [ -z $arch ]; then
+if [[ -z $arch ]]; then
     echo "ERROR: No architecture set" 1>&2
     exit 1
-elif [ $arch == "x86" ]; then
+elif [[ $arch == "x86" ]]; then
     arch_settings="
         --arch=x86 \
         --extra-ldflags=\"-CETCOMPAT\" \
-        --prefix=../../Build/$arch \
+        --prefix=$dir/ffmpeg/Build/$arch \
         "
-elif [ $arch == "x64" ]; then
+elif [[ $arch == "x64" ]]; then
     arch_settings="
         --arch=x86_64 \
         --extra-ldflags=\"-CETCOMPAT\" \
-        --prefix=../../Build/$arch \
+        --prefix=$dir/ffmpeg/Build/$arch \
         "
-elif [ $arch == "arm" ]; then
+elif [[ $arch == "arm" ]]; then
     arch_settings="
         --arch=arm \
         --as=armasm \
         --cpu=armv7 \
         --enable-thumb \
         --extra-cflags=\"-D__ARM_PCS_VFP\" \
-        --prefix=../../Build/$arch \
+        --prefix=$dir/ffmpeg/Build/$arch \
         "
-elif [ $arch == "arm64" ]; then
+elif [[ $arch == "arm64" ]]; then
     arch_settings="
         --arch=arm64 \
         --as=armasm64 \
         --cpu=armv7 \
         --enable-thumb \
         --extra-cflags=\"-D__ARM_PCS_VFP\" \
-        --prefix=../../Build/$arch \
+        --prefix=$dir/ffmpeg/Build/$arch \
         "
 else
     echo "ERROR: $arch is not a valid architecture" 1>&2
     exit 1
 fi
 
-# PREfast static analysis settings
-if [[ $prefast_rulesets ]]; then
-    prefast_settings="--extra-cflags=\"-analyze -analyze:log:includesuppressed -analyze:log:format:sarif -analyze:plugin EspXEngine.dll -analyze:ruleset $prefast_rulesets\""
+if [[ $sarif_logs ]]; then
+    sarif_logs_settings="--extra-cflags=\"-experimental:log $dir/ffmpeg/Output/$arch/\""
 fi
 
 # Fuzzer-specific settings
@@ -150,7 +155,9 @@ if [[ $fuzzing ]]; then
         exit 1
     fi
 
-    fuzz_settings="--extra-cflags=\"-fsanitize=address -fsanitize-coverage=inline-8bit-counters -fsanitize-coverage=edge -fsanitize-coverage=trace-cmp -fsanitize-coverage=trace-div\" "
+    fuzz_settings="--extra-cflags=\"\
+        -fsanitize=address -fsanitize-coverage=inline-8bit-counters -fsanitize-coverage=edge \
+        -fsanitize-coverage=trace-cmp -fsanitize-coverage=trace-div\""
 
     # Add sancov.lib or libsancov.lib based on CRT
     if [[ $crt == "dynamic" ]]; then
@@ -167,7 +174,16 @@ rm -rf Output/$arch
 mkdir -p Output/$arch
 cd Output/$arch
 
-eval ../../configure $common_settings $arch_settings $app_platform_settings $crt_settings $onecore_settings $user_settings $prefast_settings $fuzz_settings &&
+eval ../../configure \
+    $common_settings \
+    $arch_settings \
+    $app_platform_settings \
+    $crt_settings \
+    $onecore_settings \
+    $user_settings \
+    $prefast_settings \
+    $sarif_logs_settings \
+    $fuzz_settings &&
 make -j`nproc` &&
 make install
 

--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -73,7 +73,7 @@ while true; do
             for i in "${!rsps[@]}"; do
                 rsps[$i]="@$(cygpath --unix "${rsps[$i]}")"
             done
-            rsps=$(IFS=' ' echo "${rsps[*]}")
+            rsps=$(IFS=' '; echo "${rsps[*]}")
 
             compiler_rsp_settings+="--extra-cflags=\"$rsps\""
             shift 2
@@ -84,7 +84,7 @@ while true; do
             for i in "${!rulesets[@]}"; do
                 rulesets[$i]="$(cygpath --unix "${rulesets[$i]}")"
             done
-            rulesets=$(IFS=';' echo "${rulesets[*]}")
+            rulesets=$(IFS=';'; echo "${rulesets[*]}")
 
             prefast_settings="\
                 --extra-cflags=\"-analyze -analyze:log:includesuppressed -analyze:log:format:sarif -analyze:plugin \

--- a/Patches/000_armasm_flags.patch
+++ b/Patches/000_armasm_flags.patch
@@ -2,7 +2,7 @@ diff --git a/configure b/configure
 index d77a55b653..c964c00b91 100755
 --- a/configure
 +++ b/configure
-@@ -4799,11 +4799,26 @@ EOF
+@@ -4799,11 +4799,24 @@ EOF
  fi
  
  armasm_flags(){
@@ -12,10 +12,8 @@ index d77a55b653..c964c00b91 100755
 +            # Filter out any arguments for MSVC cl.exe options that were
 +            # previously filtered out below
 +            case $flag in
-+                -*) skip_arg=false ;;
-+                *)
-+                    continue
-+                    ;;
++                -*)             skip_arg=false                  ;;
++                *)              continue                        ;;
 +            esac
 +        fi
          case $flag in

--- a/Patches/000_armasm_flags.patch
+++ b/Patches/000_armasm_flags.patch
@@ -1,0 +1,30 @@
+diff --git a/configure b/configure
+index d77a55b653..c964c00b91 100755
+--- a/configure
++++ b/configure
+@@ -4799,11 +4799,25 @@ EOF
+ fi
+ 
+ armasm_flags(){
++    skip_arg=false
+     for flag; do
++        if [ "$skip_arg" = true ]; then
++            # Filter out any arguments for MSVC cl.exe options that were
++            # previously filtered out below
++            case $flag in
++                -*) skip_arg=false ;;
++                *)
++                    continue
++                    ;;
++            esac
++        fi
+         case $flag in
+             # Filter out MSVC cl.exe options from cflags that shouldn't
+             # be passed to gas-preprocessor
++            -analyze*)          skip_arg=true                   ;;
++            -experimental:log*) skip_arg=true                   ;;
+             -M[TD]*)                                            ;;
++            -Q*)                                                ;;
+             *)                  echo $flag                      ;;
+         esac
+    done

--- a/Patches/000_armasm_flags.patch
+++ b/Patches/000_armasm_flags.patch
@@ -2,7 +2,7 @@ diff --git a/configure b/configure
 index d77a55b653..c964c00b91 100755
 --- a/configure
 +++ b/configure
-@@ -4799,11 +4799,25 @@ EOF
+@@ -4799,11 +4799,26 @@ EOF
  fi
  
  armasm_flags(){
@@ -21,6 +21,7 @@ index d77a55b653..c964c00b91 100755
          case $flag in
              # Filter out MSVC cl.exe options from cflags that shouldn't
              # be passed to gas-preprocessor
++            @*)                 skip_arg=true                   ;;
 +            -analyze*)          skip_arg=true                   ;;
 +            -experimental:log*) skip_arg=true                   ;;
              -M[TD]*)                                            ;;


### PR DESCRIPTION
## Why is this change being made?
We're adding support for enabling PREfast static analysis and EO-compliant compiler warnings for FFmpeg builds.

## What changed?
- Added new optional parameters to BuildFFmpeg.ps1 and FFmpegConfig.sh:
  - Prefast - Specifies a ruleset to use for PREfast static analysis
    - See [/analyze (Code analysis) | Microsoft Learn](https://learn.microsoft.com/en-us/cpp/build/reference/analyze-code-analysis) for more info about PREfast static analysis.
  - Patches - Specifies one or more patches or directories containing patches to apply to FFmpeg before building
  - CompilerRsp - Specifies a compiler response files (.rsp) to pass to the FFmpeg build
    - See [@ (Specify a Compiler Response File) | Microsoft Learn](https://learn.microsoft.com/en-us/cpp/build/reference/at-specify-a-compiler-response-file) for more info about compiler response files.
  - SarifLogs - Specifies whether to enable SARIF output diagnostics for MSVC
    - See [Structured SARIF Diagnostics | Microsoft Learn](https://learn.microsoft.com/en-us/cpp/build/reference/sarif-output) for more info about SARIF diagnostics.
- Created 000_armasm_flags.patch to modify [armasm_flags()](https://github.com/search?q=repo%3AFFmpeg%2FFFmpeg%20armasm_flags&type=code) in FFmpeg's configure script to filter out additional MSVC compiler options and their arguments from being passed to gas-preprocessor.pl in ARM/ARM64 builds to avoid A2029 (unknown command-line argument) errors

## How was the change tested?
I built FFmpeg for x86, x64, and arm64 using BuildFFmpeg.ps1 with and without the new optional parameters.