### PR TITLE
MSFT: 58949336 - Update to FFmpeg 8.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ffmpeg"]
 	path = ffmpeg
 	url = https://github.com/FFmpeg/FFmpeg.git
-	branch = release/7.1
+	branch = release/8.0

--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -111,7 +111,7 @@ common_settings="\
     --disable-dxva2 \
     --enable-shared \
     --enable-cross-compile \
-    --extra-cflags=\"-GUARD:CF -Qspectre -Gy -Gw\" \
+    --extra-cflags=\"-guard:cf -Qspectre -Gy -Gw\" \
     --extra-ldflags=\"-PROFILE -GUARD:CF -DYNAMICBASE -OPT:ICF -OPT:REF\" \
     "
 

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -202,15 +202,15 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/FFmpegInterop/H264SampleProvider.h
+++ b/FFmpegInterop/H264SampleProvider.h
@@ -70,7 +70,7 @@ namespace winrt::FFmpegInterop::implementation
 		uint8_t GetLevel() const noexcept{ return m_level; }
 		uint32_t GetSpsId() const noexcept { return m_spsId; }
 
-		bool HasNonConstrainedBaseline() const noexcept { return m_profile == FF_PROFILE_H264_BASELINE && !GetConstraintSet1(); }
+		bool HasNonConstrainedBaseline() const noexcept { return m_profile == AV_PROFILE_H264_BASELINE && !GetConstraintSet1(); }
 
 	private:
 		uint8_t m_profile{ 0 };

--- a/FFmpegInterop/packages.config
+++ b/FFmpegInterop/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
 </packages>

--- a/Patches/000_armasm_flags.patch
+++ b/Patches/000_armasm_flags.patch
@@ -2,7 +2,7 @@ diff --git a/configure b/configure
 index 732de59292..abd004981f 100755
 --- a/configure
 +++ b/configure
-@@ -4898,11 +4898,24 @@ EOF
+@@ -4898,11 +4898,25 @@ EOF
  fi
  
  armasm_flags(){
@@ -22,6 +22,7 @@ index 732de59292..abd004981f 100755
 +            @*)                 skip_arg=true                   ;;
 +            -analyze*)          skip_arg=true                   ;;
 +            -experimental:log*) skip_arg=true                   ;;
++            -guard:*)                                           ;;
              -M[TD]*)                                            ;;
 +            -Q*)                                                ;;
              *)                  echo $flag                      ;;

--- a/Patches/000_armasm_flags.patch
+++ b/Patches/000_armasm_flags.patch
@@ -1,8 +1,8 @@
 diff --git a/configure b/configure
-index d77a55b653..c964c00b91 100755
+index 732de59292..abd004981f 100755
 --- a/configure
 +++ b/configure
-@@ -4799,11 +4799,24 @@ EOF
+@@ -4898,11 +4898,24 @@ EOF
  fi
  
  armasm_flags(){

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -185,15 +185,15 @@
   </Target>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/Samples/MediaPlayerCPP/packages.config
+++ b/Samples/MediaPlayerCPP/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
 </packages>

--- a/SetUpFFmpegBuildEnvironment.ps1
+++ b/SetUpFFmpegBuildEnvironment.ps1
@@ -80,7 +80,7 @@ for ($i = 0; $i -lt 2; $i++)
 }
 
 # Install additional packages 
-$packages = @('make', 'gcc', 'diffutils', 'yasm')
+$packages = @('make', 'gcc', 'diffutils', 'nasm')
 foreach ($package in $packages)
 {
     Write-Host "Installing $package..."

--- a/Tests/UnitTest.csproj
+++ b/Tests/UnitTest.csproj
@@ -167,16 +167,16 @@
       <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>3.6.2</Version>
+      <Version>3.10.4</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.6.2</Version>
+      <Version>3.10.4</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="System.Xml.XPath.XmlDocument">
-      <Version>4.3.0</Version>
+      <Version>4.7.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>


### PR DESCRIPTION
## Why is this change being made?
We're updating to the latest version of FFmpeg.

## What changed?
- Updated to [FFmpeg 8.0](https://github.com/FFmpeg/FFmpeg/releases/tag/n8.0)
  - [configure: treat unrecognized flags as errors on MSVC · FFmpeg/FFmpeg@bc012ac](https://github.com/FFmpeg/FFmpeg/commit/bc012ac9187b00fa8ea0e1d000ceff684775d5ee) enabled the [/options:strict (Unrecognized compiler options are errors)](https://learn.microsoft.com/en-us/cpp/build/reference/options-strict?view=msvc-170) compiler option for MSVC builds which caused a D8043 (unrecognized option) compiler error due to the `-GUARD:CF` compiler option set by ‎FFmpegConfig.sh.
    - I converted `-GUARD:CF` to lowercase `-guard:cf` in FFmpegConfig.sh. This introduced A2029 (unknown command-line argument) errors for gas-preprocessor.pl in ARM/ARM64 builds, so I also updated 000_armasm_flags.patch to filter `-guard:*` compiler options from gas-preprocessor.pl.
  - [configure: drop yasm support · FFmpeg/FFmpeg@2f888fb](https://github.com/FFmpeg/FFmpeg/commit/2f888fb99eef07a259879273bc9999c5e86620ca) dropped yasm support in favor of nasm.
    - I updated SetUpFFmpegBuildEnvironment.ps1 to install nasm instead of yasm.
  - [avcodec/defs: Add AV_PROFILE_* defines, deprecate FF_PROFILE_* defines · FFmpeg/FFmpeg@8238bc0](https://github.com/FFmpeg/FFmpeg/commit/8238bc0b5e3dba271217b1223a901b3f9713dc6e#diff-ad81ede7da099f4355c4233493a776aaff663e33c7dd66e94fb0cd9f894cd48a) replaced the FF_PROFILE_* defines in libavcodec/avcodec.h with AV_PROFILE_* defines in libavcodec/defs.h.
    - I replaced FF_PROFILE_H264_BASELINE with AV_PROFILE_H264_BASELINE in H264SampleProvider.h.
- Updated NuGet packages to the latest versions

## How was the change tested?
I validated the following scenarios:
- Ogg playback in MediaPlayerCPP
- Ogg playback in Media Player with in-proc WME and out-of-proc WME
- Internal Ogg unit tests with in-proc WME and out-of-proc WME