### PR TITLE
MSFT: 59434158 - WME ADO builds are hanging in SetUpFFmpegBuildEnvironment.ps1 while trying to update MSYS2 packages via pacman

### DIFF
--- a/SetUpFFmpegBuildEnvironment.ps1
+++ b/SetUpFFmpegBuildEnvironment.ps1
@@ -72,6 +72,7 @@ $msys2_shell = "$msys2_root\msys2_shell.cmd"
 Write-Host "Modifying $msys2_shell..."
 (Get-Content $msys2_shell).replace('rem set MSYS2_PATH_TYPE=inherit', 'set MSYS2_PATH_TYPE=inherit') | Set-Content $msys2_shell
 
+<# TODO: pacman sporadically hangs while updating packages
 # Update packages - the first pass updates core packages and the second pass updates the remaining non-core packages
 Write-Host 'Updating packages...'
 for ($i = 0; $i -lt 2; $i++)
@@ -81,6 +82,7 @@ for ($i = 0; $i -lt 2; $i++)
 
     Start-Process -Wait $msys2_shell -ArgumentList '-c "pacman -Syu --noconfirm"'
 }
+#>
 
 # Install additional packages 
 $packages = @('make', 'gcc', 'diffutils', 'nasm')

--- a/SetUpFFmpegBuildEnvironment.ps1
+++ b/SetUpFFmpegBuildEnvironment.ps1
@@ -77,9 +77,9 @@ Write-Host 'Updating packages...'
 for ($i = 0; $i -lt 2; $i++)
 {
     # Close all MSYS2 processes
-    & taskkill /FI 'MODULES eq msys-2.0.dll' /F
+    & taskkill /FI 'MODULES eq msys-2.0.dll' /F | Out-Null
 
-    Start-Process -Wait $msys2_shell -ArgumentList '-c "pacman -Syuu --noconfirm --verbose --debug --ignore pacman"'
+    Start-Process -Wait $msys2_shell -ArgumentList '-c "pacman -Syu --noconfirm"'
 }
 
 # Install additional packages 

--- a/SetUpFFmpegBuildEnvironment.ps1
+++ b/SetUpFFmpegBuildEnvironment.ps1
@@ -72,15 +72,15 @@ $msys2_shell = "$msys2_root\msys2_shell.cmd"
 Write-Host "Modifying $msys2_shell..."
 (Get-Content $msys2_shell).replace('rem set MSYS2_PATH_TYPE=inherit', 'set MSYS2_PATH_TYPE=inherit') | Set-Content $msys2_shell
 
-# Update core packages
+# Update packages - the first pass updates core packages and the second pass updates the remaining non-core packages
 Write-Host 'Updating packages...'
-Start-Process -Wait $msys2_shell -ArgumentList '-c "pacman -Syuu --noconfirm"'
+for ($i = 0; $i -lt 2; $i++)
+{
+    # Close all MSYS2 processes
+    & taskkill /FI 'MODULES eq msys-2.0.dll' /F
 
-# Close all MSYS2 processes
-& taskkill /FI 'MODULES eq msys-2.0.dll' /F
-
-# Update the remaining non-core packages
-Start-Process -Wait $msys2_shell -ArgumentList '-c "pacman -Syuu --noconfirm"'
+    Start-Process -Wait $msys2_shell -ArgumentList '-c "pacman -Syuu --noconfirm"'
+}
 
 # Install additional packages 
 $packages = @('make', 'gcc', 'diffutils', 'nasm')

--- a/SetUpFFmpegBuildEnvironment.ps1
+++ b/SetUpFFmpegBuildEnvironment.ps1
@@ -76,17 +76,10 @@ Write-Host "Modifying $msys2_shell..."
 Write-Host 'Updating packages...'
 for ($i = 0; $i -lt 2; $i++)
 {
-    $pacman_db_lock = "$msys2_root\var\lib\pacman\db.lck"
-    if (Test-Path $pacman_db_lock)
-    {
-        Write-Host "Deleting $pacman_db_lock..."
-        Remove-Item $pacman_db_lock
-    }
-
     # Close all MSYS2 processes
     & taskkill /FI 'MODULES eq msys-2.0.dll' /F
 
-    Start-Process -Wait $msys2_shell -ArgumentList '-c "pacman -Syuu --noconfirm"'
+    Start-Process -Wait $msys2_shell -ArgumentList '-c "pacman -Syu --noconfirm"'
 }
 
 # Install additional packages 

--- a/SetUpFFmpegBuildEnvironment.ps1
+++ b/SetUpFFmpegBuildEnvironment.ps1
@@ -79,7 +79,7 @@ for ($i = 0; $i -lt 2; $i++)
     # Close all MSYS2 processes
     & taskkill /FI 'MODULES eq msys-2.0.dll' /F
 
-    Start-Process -Wait $msys2_shell -ArgumentList '-c "pacman -Syu --noconfirm"'
+    Start-Process -Wait $msys2_shell -ArgumentList '-c "pacman -Syuu --noconfirm --verbose --debug --ignore pacman"'
 }
 
 # Install additional packages 

--- a/SetUpFFmpegBuildEnvironment.ps1
+++ b/SetUpFFmpegBuildEnvironment.ps1
@@ -76,6 +76,13 @@ Write-Host "Modifying $msys2_shell..."
 Write-Host 'Updating packages...'
 for ($i = 0; $i -lt 2; $i++)
 {
+    $pacman_db_lock = "$msys2_root\var\lib\pacman\db.lck"
+    if (Test-Path $pacman_db_lock)
+    {
+        Write-Host "Deleting $pacman_db_lock..."
+        Remove-Item $pacman_db_lock
+    }
+
     # Close all MSYS2 processes
     & taskkill /FI 'MODULES eq msys-2.0.dll' /F
 

--- a/SetUpFFmpegBuildEnvironment.ps1
+++ b/SetUpFFmpegBuildEnvironment.ps1
@@ -72,12 +72,15 @@ $msys2_shell = "$msys2_root\msys2_shell.cmd"
 Write-Host "Modifying $msys2_shell..."
 (Get-Content $msys2_shell).replace('rem set MSYS2_PATH_TYPE=inherit', 'set MSYS2_PATH_TYPE=inherit') | Set-Content $msys2_shell
 
-# Update packages
+# Update core packages
 Write-Host 'Updating packages...'
-for ($i = 0; $i -lt 2; $i++)
-{
-    Start-Process -Wait $msys2_shell -ArgumentList '-c "pacman -Syuu --noconfirm"'
-}
+Start-Process -Wait $msys2_shell -ArgumentList '-c "pacman -Syuu --noconfirm"'
+
+# Close all MSYS2 processes
+& taskkill /FI 'MODULES eq msys-2.0.dll' /F
+
+# Update the remaining non-core packages
+Start-Process -Wait $msys2_shell -ArgumentList '-c "pacman -Syuu --noconfirm"'
 
 # Install additional packages 
 $packages = @('make', 'gcc', 'diffutils', 'nasm')

--- a/SetUpFFmpegBuildEnvironment.ps1
+++ b/SetUpFFmpegBuildEnvironment.ps1
@@ -80,7 +80,7 @@ for ($i = 0; $i -lt 2; $i++)
     # Close all MSYS2 processes
     & taskkill /FI 'MODULES eq msys-2.0.dll' /F | Out-Null
 
-    Start-Process -Wait $msys2_shell -ArgumentList '-c "pacman -Syu --noconfirm"'
+    Start-Process -Wait $msys2_shell -ArgumentList '-c "pacman -Syuu --noconfirm"'
 }
 #>
 


### PR DESCRIPTION
## Why is this change being made?
WME ADO builds are sporadically hanging in SetUpFFmpegBuildEnvironment.ps1 while trying to update MSYS2 packages via pacman. This issue has also been reported by #324.

I'm not able to repro the hang locally on my dev machine, and I haven't been able to root cause the hang or find a workaround for the WME ADO build.

## What changed?
I disabled MSYS2 package updates via pacman in SetUpFFmpegBuildEnvironment.ps1 until the sporadic hang can be mitigated.

## How was the change tested?
I verified that WME ADO builds run successfully.